### PR TITLE
rename local_event_queue -> execution_event_queue

### DIFF
--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -158,7 +158,7 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_events_executor_callback(
+  set_listener_callback(
     const rclcpp::executors::EventsExecutor * executor,
     rmw_listener_cb_t executor_callback) const;
 

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -160,7 +160,7 @@ public:
   void
   set_events_executor_callback(
     const rclcpp::executors::EventsExecutor * executor,
-    EventsExecutorCallback executor_callback) const;
+    rmw_listener_cb_t executor_callback) const;
 
   RCLCPP_PUBLIC
   void

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -158,7 +158,7 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_listener_callback(
+  set_events_executor_callback(
     const rclcpp::executors::EventsExecutor * executor,
     rmw_listener_cb_t executor_callback) const;
 

--- a/rclcpp/include/rclcpp/executors/events_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor.hpp
@@ -26,7 +26,7 @@
 #include "rclcpp/executors/timers_manager.hpp"
 #include "rclcpp/node.hpp"
 
-#include "rmw/executor_event_types.h"
+#include "rmw/listener_event_types.h"
 
 namespace rclcpp
 {
@@ -176,13 +176,13 @@ private:
 
   // Event queue implementation is a deque only to
   // facilitate the removal of events from expired entities.
-  using EventQueue = std::deque<ExecutorEvent>;
+  using EventQueue = std::deque<rmw_listener_event_t>;
 
   // Executor callback: Push new events into the queue and trigger cv.
   // This function is called by the DDS entities when an event happened,
   // like a subscription receiving a message.
   static void
-  push_event(const void * executor_ptr, ExecutorEvent event)
+  push_event(const void * executor_ptr, rmw_listener_event_t event)
   {
     // Cast executor_ptr to this (need to remove constness)
     auto this_executor = const_cast<executors::EventsExecutor *>(
@@ -217,7 +217,7 @@ private:
       event_queue_.erase(
         std::remove_if(
           event_queue_.begin(), event_queue_.end(),
-          [&entity](ExecutorEvent event) {return event.entity == entity;}), event_queue_.end());
+          [&entity](rmw_listener_event_t event) {return event.entity == entity;}), event_queue_.end());
     }
 
     // Remove events associated with this entity from the local event queue
@@ -226,7 +226,7 @@ private:
       execution_event_queue_.erase(
         std::remove_if(
           execution_event_queue_.begin(), execution_event_queue_.end(),
-          [&entity](ExecutorEvent event) {
+          [&entity](rmw_listener_event_t event) {
             return event.entity == entity;
           }), execution_event_queue_.end());
     }
@@ -240,7 +240,7 @@ private:
   // Execute a single event
   RCLCPP_PUBLIC
   void
-  execute_event(const ExecutorEvent & event);
+  execute_event(const rmw_listener_event_t & event);
 
   // We use two instances of EventQueue to allow threads to push events while we execute them
   EventQueue event_queue_;

--- a/rclcpp/include/rclcpp/executors/events_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor.hpp
@@ -209,7 +209,7 @@ private:
     // We need to unset the callbacks to make sure that after removing events from the
     // queues, this entity will not push anymore before being completely destroyed.
     // This assumes that all supported entities implement this function.
-    entity->set_listener_callback(nullptr, nullptr);
+    entity->set_events_executor_callback(nullptr, nullptr);
 
     // Remove events associated with this entity from the event queue
     {

--- a/rclcpp/include/rclcpp/executors/events_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor.hpp
@@ -223,12 +223,12 @@ private:
     // Remove events associated with this entity from the local event queue
     {
       std::unique_lock<std::mutex> lock(execution_mutex_);
-      local_event_queue_.erase(
+      execution_event_queue_.erase(
         std::remove_if(
-          local_event_queue_.begin(), local_event_queue_.end(),
+          execution_event_queue_.begin(), execution_event_queue_.end(),
           [&entity](ExecutorEvent event) {
             return event.entity == entity;
-          }), local_event_queue_.end());
+          }), execution_event_queue_.end());
     }
   }
 
@@ -244,7 +244,7 @@ private:
 
   // We use two instances of EventQueue to allow threads to push events while we execute them
   EventQueue event_queue_;
-  EventQueue local_event_queue_;
+  EventQueue execution_event_queue_;
 
   EventsExecutorEntitiesCollector::SharedPtr entities_collector_;
   EventsExecutorNotifyWaitable::SharedPtr executor_notifier_;

--- a/rclcpp/include/rclcpp/executors/events_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor.hpp
@@ -209,7 +209,7 @@ private:
     // We need to unset the callbacks to make sure that after removing events from the
     // queues, this entity will not push anymore before being completely destroyed.
     // This assumes that all supported entities implement this function.
-    entity->set_events_executor_callback(nullptr, nullptr);
+    entity->set_listener_callback(nullptr, nullptr);
 
     // Remove events associated with this entity from the event queue
     {

--- a/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
@@ -62,12 +62,12 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_events_executor_callback(
+  set_listener_callback(
     const rclcpp::executors::EventsExecutor * executor,
     rmw_listener_cb_t executor_callback) const override
   {
     for (auto gc : notify_guard_conditions_) {
-      rcl_ret_t ret = rcl_guard_condition_set_events_executor_callback(
+      rcl_ret_t ret = rcl_guard_condition_set_listener_callback(
         executor,
         executor_callback,
         this,

--- a/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
@@ -64,7 +64,7 @@ public:
   void
   set_events_executor_callback(
     const rclcpp::executors::EventsExecutor * executor,
-    EventsExecutorCallback executor_callback) const override
+    rmw_listener_cb_t executor_callback) const override
   {
     for (auto gc : notify_guard_conditions_) {
       rcl_ret_t ret = rcl_guard_condition_set_events_executor_callback(

--- a/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
@@ -62,7 +62,7 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_listener_callback(
+  set_events_executor_callback(
     const rclcpp::executors::EventsExecutor * executor,
     rmw_listener_cb_t executor_callback) const override
   {

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -72,7 +72,7 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_listener_callback(
+  set_events_executor_callback(
     const rclcpp::executors::EventsExecutor * executor,
     rmw_listener_cb_t executor_callback) const override;
 

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -74,7 +74,7 @@ public:
   void
   set_events_executor_callback(
     const rclcpp::executors::EventsExecutor * executor,
-    EventsExecutorCallback executor_callback) const override;
+    rmw_listener_cb_t executor_callback) const override;
 
 protected:
   std::recursive_mutex reentrant_mutex_;

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -72,7 +72,7 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_events_executor_callback(
+  set_listener_callback(
     const rclcpp::executors::EventsExecutor * executor,
     rmw_listener_cb_t executor_callback) const override;
 

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -108,7 +108,7 @@ public:
   /// Set EventsExecutor's callback
   RCLCPP_PUBLIC
   void
-  set_listener_callback(
+  set_events_executor_callback(
     const rclcpp::executors::EventsExecutor * executor,
     rmw_listener_cb_t executor_callback) const override;
 

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -110,7 +110,7 @@ public:
   void
   set_events_executor_callback(
     const rclcpp::executors::EventsExecutor * executor,
-    EventsExecutorCallback executor_callback) const override;
+    rmw_listener_cb_t executor_callback) const override;
 
 protected:
   rcl_event_t event_handle_;

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -108,7 +108,7 @@ public:
   /// Set EventsExecutor's callback
   RCLCPP_PUBLIC
   void
-  set_events_executor_callback(
+  set_listener_callback(
     const rclcpp::executors::EventsExecutor * executor,
     rmw_listener_cb_t executor_callback) const override;
 

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -128,7 +128,7 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_listener_callback(
+  set_events_executor_callback(
     const rclcpp::executors::EventsExecutor * executor,
     rmw_listener_cb_t executor_callback) const;
 

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -128,7 +128,7 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_events_executor_callback(
+  set_listener_callback(
     const rclcpp::executors::EventsExecutor * executor,
     rmw_listener_cb_t executor_callback) const;
 

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -130,7 +130,7 @@ public:
   void
   set_events_executor_callback(
     const rclcpp::executors::EventsExecutor * executor,
-    EventsExecutorCallback executor_callback) const;
+    rmw_listener_cb_t executor_callback) const;
 
   RCLCPP_PUBLIC
   void

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -271,7 +271,7 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_events_executor_callback(
+  set_listener_callback(
     const rclcpp::executors::EventsExecutor * executor,
     rmw_listener_cb_t executor_callback) const;
 

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -271,7 +271,7 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_listener_callback(
+  set_events_executor_callback(
     const rclcpp::executors::EventsExecutor * executor,
     rmw_listener_cb_t executor_callback) const;
 

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -273,7 +273,7 @@ public:
   void
   set_events_executor_callback(
     const rclcpp::executors::EventsExecutor * executor,
-    EventsExecutorCallback executor_callback) const;
+    rmw_listener_cb_t executor_callback) const;
 
   RCLCPP_PUBLIC
   void

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -176,7 +176,7 @@ public:
   void
   set_events_executor_callback(
     const rclcpp::executors::EventsExecutor * executor,
-    EventsExecutorCallback executor_callback) const;
+    rmw_listener_cb_t executor_callback) const;
 
   RCLCPP_PUBLIC
   void

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -174,7 +174,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   void
-  set_listener_callback(
+  set_events_executor_callback(
     const rclcpp::executors::EventsExecutor * executor,
     rmw_listener_cb_t executor_callback) const;
 

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -174,7 +174,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   void
-  set_events_executor_callback(
+  set_listener_callback(
     const rclcpp::executors::EventsExecutor * executor,
     rmw_listener_cb_t executor_callback) const;
 

--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -205,7 +205,7 @@ ClientBase::exchange_in_use_by_wait_set_state(bool in_use_state)
 void
 ClientBase::set_events_executor_callback(
   const rclcpp::executors::EventsExecutor * executor,
-  EventsExecutorCallback executor_callback) const
+  rmw_listener_cb_t executor_callback) const
 {
   rcl_ret_t ret = rcl_client_set_events_executor_callback(
     executor,

--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -203,11 +203,11 @@ ClientBase::exchange_in_use_by_wait_set_state(bool in_use_state)
 }
 
 void
-ClientBase::set_events_executor_callback(
+ClientBase::set_listener_callback(
   const rclcpp::executors::EventsExecutor * executor,
   rmw_listener_cb_t executor_callback) const
 {
-  rcl_ret_t ret = rcl_client_set_events_executor_callback(
+  rcl_ret_t ret = rcl_client_set_listener_callback(
     executor,
     executor_callback,
     this,

--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -203,7 +203,7 @@ ClientBase::exchange_in_use_by_wait_set_state(bool in_use_state)
 }
 
 void
-ClientBase::set_listener_callback(
+ClientBase::set_events_executor_callback(
   const rclcpp::executors::EventsExecutor * executor,
   rmw_listener_cb_t executor_callback) const
 {

--- a/rclcpp/src/rclcpp/executors/events_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/events_executor.cpp
@@ -40,7 +40,7 @@ EventsExecutor::EventsExecutor(
   executor_notifier_ = std::make_shared<EventsExecutorNotifyWaitable>();
   executor_notifier_->add_guard_condition(context_interrupt_gc);
   executor_notifier_->add_guard_condition(&interrupt_guard_condition_);
-  executor_notifier_->set_events_executor_callback(this, &EventsExecutor::push_event);
+  executor_notifier_->set_listener_callback(this, &EventsExecutor::push_event);
   executor_notifier_->set_on_destruction_callback(
     std::bind(
       &EventsExecutor::remove_entity<rclcpp::Waitable>,

--- a/rclcpp/src/rclcpp/executors/events_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/events_executor.cpp
@@ -40,7 +40,7 @@ EventsExecutor::EventsExecutor(
   executor_notifier_ = std::make_shared<EventsExecutorNotifyWaitable>();
   executor_notifier_->add_guard_condition(context_interrupt_gc);
   executor_notifier_->add_guard_condition(&interrupt_guard_condition_);
-  executor_notifier_->set_listener_callback(this, &EventsExecutor::push_event);
+  executor_notifier_->set_events_executor_callback(this, &EventsExecutor::push_event);
   executor_notifier_->set_on_destruction_callback(
     std::bind(
       &EventsExecutor::remove_entity<rclcpp::Waitable>,

--- a/rclcpp/src/rclcpp/executors/events_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/events_executor.cpp
@@ -189,7 +189,7 @@ EventsExecutor::spin_once_impl(std::chrono::nanoseconds timeout)
   // When condition variable is notified, check this predicate to proceed
   auto has_event_predicate = [this]() {return !event_queue_.empty();};
 
-  ExecutorEvent event;
+  rmw_listener_event_t event;
   bool has_event = false;
 
   {
@@ -255,7 +255,7 @@ void
 EventsExecutor::consume_all_events(EventQueue & event_queue)
 {
   while (!event_queue.empty()) {
-    ExecutorEvent event = event_queue.front();
+    rmw_listener_event_t event = event_queue.front();
     event_queue.pop_front();
 
     this->execute_event(event);
@@ -263,7 +263,7 @@ EventsExecutor::consume_all_events(EventQueue & event_queue)
 }
 
 void
-EventsExecutor::execute_event(const ExecutorEvent & event)
+EventsExecutor::execute_event(const rmw_listener_event_t & event)
 {
   switch (event.type) {
     case SUBSCRIPTION_EVENT:

--- a/rclcpp/src/rclcpp/executors/events_executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/events_executor_entities_collector.cpp
@@ -224,7 +224,7 @@ EventsExecutorEntitiesCollector::set_callback_group_entities_callbacks(
   group->find_subscription_ptrs_if(
     [this](const rclcpp::SubscriptionBase::SharedPtr & subscription) {
       if (subscription) {
-        subscription->set_listener_callback(
+        subscription->set_events_executor_callback(
           associated_executor_,
           &EventsExecutor::push_event);
         subscription->set_on_destruction_callback(
@@ -238,7 +238,7 @@ EventsExecutorEntitiesCollector::set_callback_group_entities_callbacks(
   group->find_service_ptrs_if(
     [this](const rclcpp::ServiceBase::SharedPtr & service) {
       if (service) {
-        service->set_listener_callback(
+        service->set_events_executor_callback(
           associated_executor_,
           &EventsExecutor::push_event);
         service->set_on_destruction_callback(
@@ -252,7 +252,7 @@ EventsExecutorEntitiesCollector::set_callback_group_entities_callbacks(
   group->find_client_ptrs_if(
     [this](const rclcpp::ClientBase::SharedPtr & client) {
       if (client) {
-        client->set_listener_callback(
+        client->set_events_executor_callback(
           associated_executor_,
           &EventsExecutor::push_event);
         client->set_on_destruction_callback(
@@ -266,7 +266,7 @@ EventsExecutorEntitiesCollector::set_callback_group_entities_callbacks(
   group->find_waitable_ptrs_if(
     [this](const rclcpp::Waitable::SharedPtr & waitable) {
       if (waitable) {
-        waitable->set_listener_callback(
+        waitable->set_events_executor_callback(
           associated_executor_,
           &EventsExecutor::push_event);
         waitable->set_on_destruction_callback(
@@ -297,7 +297,7 @@ EventsExecutorEntitiesCollector::unset_callback_group_entities_callbacks(
   group->find_subscription_ptrs_if(
     [this](const rclcpp::SubscriptionBase::SharedPtr & subscription) {
       if (subscription) {
-        subscription->set_listener_callback(nullptr, nullptr);
+        subscription->set_events_executor_callback(nullptr, nullptr);
         subscription->set_on_destruction_callback(nullptr);
       }
       return false;
@@ -305,7 +305,7 @@ EventsExecutorEntitiesCollector::unset_callback_group_entities_callbacks(
   group->find_service_ptrs_if(
     [this](const rclcpp::ServiceBase::SharedPtr & service) {
       if (service) {
-        service->set_listener_callback(nullptr, nullptr);
+        service->set_events_executor_callback(nullptr, nullptr);
         service->set_on_destruction_callback(nullptr);
       }
       return false;
@@ -313,7 +313,7 @@ EventsExecutorEntitiesCollector::unset_callback_group_entities_callbacks(
   group->find_client_ptrs_if(
     [this](const rclcpp::ClientBase::SharedPtr & client) {
       if (client) {
-        client->set_listener_callback(nullptr, nullptr);
+        client->set_events_executor_callback(nullptr, nullptr);
         client->set_on_destruction_callback(nullptr);
       }
       return false;
@@ -321,7 +321,7 @@ EventsExecutorEntitiesCollector::unset_callback_group_entities_callbacks(
   group->find_waitable_ptrs_if(
     [this](const rclcpp::Waitable::SharedPtr & waitable) {
       if (waitable) {
-        waitable->set_listener_callback(nullptr, nullptr);
+        waitable->set_events_executor_callback(nullptr, nullptr);
         waitable->set_on_destruction_callback(nullptr);
       }
       return false;

--- a/rclcpp/src/rclcpp/executors/events_executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/events_executor_entities_collector.cpp
@@ -224,7 +224,7 @@ EventsExecutorEntitiesCollector::set_callback_group_entities_callbacks(
   group->find_subscription_ptrs_if(
     [this](const rclcpp::SubscriptionBase::SharedPtr & subscription) {
       if (subscription) {
-        subscription->set_events_executor_callback(
+        subscription->set_listener_callback(
           associated_executor_,
           &EventsExecutor::push_event);
         subscription->set_on_destruction_callback(
@@ -238,7 +238,7 @@ EventsExecutorEntitiesCollector::set_callback_group_entities_callbacks(
   group->find_service_ptrs_if(
     [this](const rclcpp::ServiceBase::SharedPtr & service) {
       if (service) {
-        service->set_events_executor_callback(
+        service->set_listener_callback(
           associated_executor_,
           &EventsExecutor::push_event);
         service->set_on_destruction_callback(
@@ -252,7 +252,7 @@ EventsExecutorEntitiesCollector::set_callback_group_entities_callbacks(
   group->find_client_ptrs_if(
     [this](const rclcpp::ClientBase::SharedPtr & client) {
       if (client) {
-        client->set_events_executor_callback(
+        client->set_listener_callback(
           associated_executor_,
           &EventsExecutor::push_event);
         client->set_on_destruction_callback(
@@ -266,7 +266,7 @@ EventsExecutorEntitiesCollector::set_callback_group_entities_callbacks(
   group->find_waitable_ptrs_if(
     [this](const rclcpp::Waitable::SharedPtr & waitable) {
       if (waitable) {
-        waitable->set_events_executor_callback(
+        waitable->set_listener_callback(
           associated_executor_,
           &EventsExecutor::push_event);
         waitable->set_on_destruction_callback(
@@ -297,7 +297,7 @@ EventsExecutorEntitiesCollector::unset_callback_group_entities_callbacks(
   group->find_subscription_ptrs_if(
     [this](const rclcpp::SubscriptionBase::SharedPtr & subscription) {
       if (subscription) {
-        subscription->set_events_executor_callback(nullptr, nullptr);
+        subscription->set_listener_callback(nullptr, nullptr);
         subscription->set_on_destruction_callback(nullptr);
       }
       return false;
@@ -305,7 +305,7 @@ EventsExecutorEntitiesCollector::unset_callback_group_entities_callbacks(
   group->find_service_ptrs_if(
     [this](const rclcpp::ServiceBase::SharedPtr & service) {
       if (service) {
-        service->set_events_executor_callback(nullptr, nullptr);
+        service->set_listener_callback(nullptr, nullptr);
         service->set_on_destruction_callback(nullptr);
       }
       return false;
@@ -313,7 +313,7 @@ EventsExecutorEntitiesCollector::unset_callback_group_entities_callbacks(
   group->find_client_ptrs_if(
     [this](const rclcpp::ClientBase::SharedPtr & client) {
       if (client) {
-        client->set_events_executor_callback(nullptr, nullptr);
+        client->set_listener_callback(nullptr, nullptr);
         client->set_on_destruction_callback(nullptr);
       }
       return false;
@@ -321,7 +321,7 @@ EventsExecutorEntitiesCollector::unset_callback_group_entities_callbacks(
   group->find_waitable_ptrs_if(
     [this](const rclcpp::Waitable::SharedPtr & waitable) {
       if (waitable) {
-        waitable->set_events_executor_callback(nullptr, nullptr);
+        waitable->set_listener_callback(nullptr, nullptr);
         waitable->set_on_destruction_callback(nullptr);
       }
       return false;
@@ -484,7 +484,7 @@ void
 EventsExecutorEntitiesCollector::set_guard_condition_callback(
   const rcl_guard_condition_t * guard_condition)
 {
-  rcl_ret_t ret = rcl_guard_condition_set_events_executor_callback(
+  rcl_ret_t ret = rcl_guard_condition_set_listener_callback(
     associated_executor_,
     &EventsExecutor::push_event,
     this,
@@ -500,7 +500,7 @@ void
 EventsExecutorEntitiesCollector::unset_guard_condition_callback(
   const rcl_guard_condition_t * guard_condition)
 {
-  rcl_ret_t ret = rcl_guard_condition_set_events_executor_callback(
+  rcl_ret_t ret = rcl_guard_condition_set_listener_callback(
     nullptr,
     nullptr,
     nullptr,

--- a/rclcpp/src/rclcpp/qos_event.cpp
+++ b/rclcpp/src/rclcpp/qos_event.cpp
@@ -73,11 +73,11 @@ QOSEventHandlerBase::is_ready(rcl_wait_set_t * wait_set)
 }
 
 void
-QOSEventHandlerBase::set_events_executor_callback(
+QOSEventHandlerBase::set_listener_callback(
   const rclcpp::executors::EventsExecutor * executor,
   rmw_listener_cb_t executor_callback) const
 {
-  rcl_ret_t ret = rcl_event_set_events_executor_callback(
+  rcl_ret_t ret = rcl_event_set_listener_callback(
     executor,
     executor_callback,
     this,

--- a/rclcpp/src/rclcpp/qos_event.cpp
+++ b/rclcpp/src/rclcpp/qos_event.cpp
@@ -75,7 +75,7 @@ QOSEventHandlerBase::is_ready(rcl_wait_set_t * wait_set)
 void
 QOSEventHandlerBase::set_events_executor_callback(
   const rclcpp::executors::EventsExecutor * executor,
-  EventsExecutorCallback executor_callback) const
+  rmw_listener_cb_t executor_callback) const
 {
   rcl_ret_t ret = rcl_event_set_events_executor_callback(
     executor,

--- a/rclcpp/src/rclcpp/qos_event.cpp
+++ b/rclcpp/src/rclcpp/qos_event.cpp
@@ -73,7 +73,7 @@ QOSEventHandlerBase::is_ready(rcl_wait_set_t * wait_set)
 }
 
 void
-QOSEventHandlerBase::set_listener_callback(
+QOSEventHandlerBase::set_events_executor_callback(
   const rclcpp::executors::EventsExecutor * executor,
   rmw_listener_cb_t executor_callback) const
 {

--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -92,7 +92,7 @@ ServiceBase::exchange_in_use_by_wait_set_state(bool in_use_state)
 void
 ServiceBase::set_events_executor_callback(
   const rclcpp::executors::EventsExecutor * executor,
-  EventsExecutorCallback executor_callback) const
+  rmw_listener_cb_t executor_callback) const
 {
   rcl_ret_t ret = rcl_service_set_events_executor_callback(
     executor,

--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -90,11 +90,11 @@ ServiceBase::exchange_in_use_by_wait_set_state(bool in_use_state)
 }
 
 void
-ServiceBase::set_events_executor_callback(
+ServiceBase::set_listener_callback(
   const rclcpp::executors::EventsExecutor * executor,
   rmw_listener_cb_t executor_callback) const
 {
-  rcl_ret_t ret = rcl_service_set_events_executor_callback(
+  rcl_ret_t ret = rcl_service_set_listener_callback(
     executor,
     executor_callback,
     this,

--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -90,7 +90,7 @@ ServiceBase::exchange_in_use_by_wait_set_state(bool in_use_state)
 }
 
 void
-ServiceBase::set_listener_callback(
+ServiceBase::set_events_executor_callback(
   const rclcpp::executors::EventsExecutor * executor,
   rmw_listener_cb_t executor_callback) const
 {

--- a/rclcpp/src/rclcpp/subscription_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_base.cpp
@@ -294,11 +294,11 @@ SubscriptionBase::exchange_in_use_by_wait_set_state(
 }
 
 void
-SubscriptionBase::set_events_executor_callback(
+SubscriptionBase::set_listener_callback(
   const rclcpp::executors::EventsExecutor * executor,
   rmw_listener_cb_t executor_callback) const
 {
-  rcl_ret_t ret = rcl_subscription_set_events_executor_callback(
+  rcl_ret_t ret = rcl_subscription_set_listener_callback(
     executor,
     executor_callback,
     this,

--- a/rclcpp/src/rclcpp/subscription_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_base.cpp
@@ -294,7 +294,7 @@ SubscriptionBase::exchange_in_use_by_wait_set_state(
 }
 
 void
-SubscriptionBase::set_listener_callback(
+SubscriptionBase::set_events_executor_callback(
   const rclcpp::executors::EventsExecutor * executor,
   rmw_listener_cb_t executor_callback) const
 {

--- a/rclcpp/src/rclcpp/subscription_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_base.cpp
@@ -296,7 +296,7 @@ SubscriptionBase::exchange_in_use_by_wait_set_state(
 void
 SubscriptionBase::set_events_executor_callback(
   const rclcpp::executors::EventsExecutor * executor,
-  EventsExecutorCallback executor_callback) const
+  rmw_listener_cb_t executor_callback) const
 {
   rcl_ret_t ret = rcl_subscription_set_events_executor_callback(
     executor,

--- a/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
@@ -45,11 +45,11 @@ SubscriptionIntraProcessBase::get_actual_qos() const
 }
 
 void
-SubscriptionIntraProcessBase::set_events_executor_callback(
+SubscriptionIntraProcessBase::set_listener_callback(
   const rclcpp::executors::EventsExecutor * executor,
   rmw_listener_cb_t executor_callback) const
 {
-  rcl_ret_t ret = rcl_guard_condition_set_events_executor_callback(
+  rcl_ret_t ret = rcl_guard_condition_set_listener_callback(
     executor,
     executor_callback,
     this,

--- a/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
@@ -45,7 +45,7 @@ SubscriptionIntraProcessBase::get_actual_qos() const
 }
 
 void
-SubscriptionIntraProcessBase::set_listener_callback(
+SubscriptionIntraProcessBase::set_events_executor_callback(
   const rclcpp::executors::EventsExecutor * executor,
   rmw_listener_cb_t executor_callback) const
 {

--- a/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
@@ -47,7 +47,7 @@ SubscriptionIntraProcessBase::get_actual_qos() const
 void
 SubscriptionIntraProcessBase::set_events_executor_callback(
   const rclcpp::executors::EventsExecutor * executor,
-  EventsExecutorCallback executor_callback) const
+  rmw_listener_cb_t executor_callback) const
 {
   rcl_ret_t ret = rcl_guard_condition_set_events_executor_callback(
     executor,

--- a/rclcpp/src/rclcpp/waitable.cpp
+++ b/rclcpp/src/rclcpp/waitable.cpp
@@ -63,7 +63,7 @@ Waitable::exchange_in_use_by_wait_set_state(bool in_use_state)
 void
 Waitable::set_events_executor_callback(
   const rclcpp::executors::EventsExecutor * executor,
-  EventsExecutorCallback executor_callback) const
+  rmw_listener_cb_t executor_callback) const
 {
   (void)executor;
   (void)executor_callback;

--- a/rclcpp/src/rclcpp/waitable.cpp
+++ b/rclcpp/src/rclcpp/waitable.cpp
@@ -61,7 +61,7 @@ Waitable::exchange_in_use_by_wait_set_state(bool in_use_state)
 }
 
 void
-Waitable::set_events_executor_callback(
+Waitable::set_listener_callback(
   const rclcpp::executors::EventsExecutor * executor,
   rmw_listener_cb_t executor_callback) const
 {
@@ -69,7 +69,7 @@ Waitable::set_events_executor_callback(
   (void)executor_callback;
 
   throw std::runtime_error(
-          "Custom waitables should override set_events_executor_callback() to use events executor");
+          "Custom waitables should override set_listener_callback() to use events executor");
 }
 
 void

--- a/rclcpp/src/rclcpp/waitable.cpp
+++ b/rclcpp/src/rclcpp/waitable.cpp
@@ -61,7 +61,7 @@ Waitable::exchange_in_use_by_wait_set_state(bool in_use_state)
 }
 
 void
-Waitable::set_listener_callback(
+Waitable::set_events_executor_callback(
   const rclcpp::executors::EventsExecutor * executor,
   rmw_listener_cb_t executor_callback) const
 {
@@ -69,7 +69,7 @@ Waitable::set_listener_callback(
   (void)executor_callback;
 
   throw std::runtime_error(
-          "Custom waitables should override set_listener_callback() to use events executor");
+          "Custom waitables should override set_events_executor_callback() to use events executor");
 }
 
 void

--- a/rclcpp/test/rclcpp/executors/test_events_executor.cpp
+++ b/rclcpp/test/rclcpp/executors/test_events_executor.cpp
@@ -54,7 +54,7 @@ TEST_F(TestEventsExecutor, notify_waitable)
 
   {
     auto mock = mocking_utils::patch_and_return(
-      "lib:rclcpp", rcl_guard_condition_set_events_executor_callback, RCL_RET_ERROR);
+      "lib:rclcpp", rcl_guard_condition_set_listener_callback, RCL_RET_ERROR);
     EXPECT_THROW(std::make_shared<EventsExecutor>(), std::runtime_error);
   }
 }

--- a/rclcpp/test/rclcpp/executors/test_events_executor_entities_collector.cpp
+++ b/rclcpp/test/rclcpp/executors/test_events_executor_entities_collector.cpp
@@ -165,7 +165,7 @@ TEST_F(TestEventsExecutorEntitiesCollector, test_fancy_name)
 
   {
     auto mock = mocking_utils::patch_and_return(
-      "lib:rclcpp", rcl_guard_condition_set_events_executor_callback, RCL_RET_ERROR);
+      "lib:rclcpp", rcl_guard_condition_set_listener_callback, RCL_RET_ERROR);
 
     EXPECT_THROW(
       entities_collector_->add_node(node2->get_node_base_interface()),

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -465,7 +465,7 @@ public:
   }
 
   void
-  set_listener_callback(
+  set_events_executor_callback(
     const rclcpp::executors::EventsExecutor * executor,
     rmw_listener_cb_t executor_callback) const override
   {

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -467,7 +467,7 @@ public:
   void
   set_events_executor_callback(
     const rclcpp::executors::EventsExecutor * executor,
-    EventsExecutorCallback executor_callback) const override
+    rmw_listener_cb_t executor_callback) const override
   {
     rcl_ret_t ret = rcl_guard_condition_set_events_executor_callback(
       executor,

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -465,11 +465,11 @@ public:
   }
 
   void
-  set_events_executor_callback(
+  set_listener_callback(
     const rclcpp::executors::EventsExecutor * executor,
     rmw_listener_cb_t executor_callback) const override
   {
-    rcl_ret_t ret = rcl_guard_condition_set_events_executor_callback(
+    rcl_ret_t ret = rcl_guard_condition_set_listener_callback(
       executor,
       executor_callback,
       this,


### PR DESCRIPTION
This PR also renames:
`local_event_queue_` to `execution_event_queue_`