### PR TITLE
Implement no-op on IPC subscription

### DIFF
--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -185,6 +185,12 @@ public:
     ConstMessageSharedPtr message, const rclcpp::MessageInfo & message_info)
   {
     TRACEPOINT(callback_start, static_cast<const void *>(this), true);
+
+    // If the message is not valid, return.
+    if(!message) {
+      return;
+    }
+
     if (const_shared_ptr_callback_) {
       const_shared_ptr_callback_(message);
     } else if (const_shared_ptr_with_info_callback_) {
@@ -208,6 +214,12 @@ public:
     MessageUniquePtr message, const rclcpp::MessageInfo & message_info)
   {
     TRACEPOINT(callback_start, static_cast<const void *>(this), true);
+
+    // If the message is not valid, return.
+    if(!message) {
+      return;
+    }
+
     if (shared_ptr_callback_) {
       typename std::shared_ptr<MessageT> shared_message = std::move(message);
       shared_ptr_callback_(shared_message);

--- a/rclcpp/include/rclcpp/experimental/buffers/ring_buffer_implementation.hpp
+++ b/rclcpp/include/rclcpp/experimental/buffers/ring_buffer_implementation.hpp
@@ -73,6 +73,7 @@ public:
     ring_buffer_[write_index_] = std::move(request);
 
     if (is_full_()) {
+      RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Ring buffer is full! Buffer capacity: %d", capacity_);
       read_index_ = next_(read_index_);
     } else {
       size_++;

--- a/rclcpp/include/rclcpp/experimental/buffers/ring_buffer_implementation.hpp
+++ b/rclcpp/include/rclcpp/experimental/buffers/ring_buffer_implementation.hpp
@@ -73,7 +73,6 @@ public:
     ring_buffer_[write_index_] = std::move(request);
 
     if (is_full_()) {
-      RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Ring buffer is full! Buffer capacity: %lu", capacity_);
       read_index_ = next_(read_index_);
     } else {
       size_++;

--- a/rclcpp/include/rclcpp/experimental/buffers/ring_buffer_implementation.hpp
+++ b/rclcpp/include/rclcpp/experimental/buffers/ring_buffer_implementation.hpp
@@ -73,7 +73,7 @@ public:
     ring_buffer_[write_index_] = std::move(request);
 
     if (is_full_()) {
-      RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Ring buffer is full! Buffer capacity: %d", capacity_);
+      RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Ring buffer is full! Buffer capacity: %lu", capacity_);
       read_index_ = next_(read_index_);
     } else {
       size_++;

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
@@ -129,8 +129,14 @@ public:
 
     if (any_callback_.use_take_shared_method()) {
       shared_msg = buffer_->consume_shared();
+      if(!shared_msg) {
+        return nullptr;
+      }
     } else {
       unique_msg = buffer_->consume_unique();
+      if(!unique_msg) {
+        return nullptr;
+      }
     }
     return std::static_pointer_cast<void>(
       std::make_shared<std::pair<ConstMessageSharedPtr, MessageUniquePtr>>(
@@ -185,7 +191,8 @@ private:
   execute_impl(std::shared_ptr<void> & data)
   {
     if (!data) {
-      throw std::runtime_error("'data' is empty");
+      RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Subscription intra-process: 'data' is empty");
+      return;
     }
 
     rmw_message_info_t msg_info;

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
@@ -129,14 +129,8 @@ public:
 
     if (any_callback_.use_take_shared_method()) {
       shared_msg = buffer_->consume_shared();
-      if(!shared_msg) {
-        return nullptr;
-      }
     } else {
       unique_msg = buffer_->consume_unique();
-      if(!unique_msg) {
-        return nullptr;
-      }
     }
     return std::static_pointer_cast<void>(
       std::make_shared<std::pair<ConstMessageSharedPtr, MessageUniquePtr>>(

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
@@ -185,8 +185,7 @@ private:
   execute_impl(std::shared_ptr<void> & data)
   {
     if (!data) {
-      RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Subscription intra-process: 'data' is empty");
-      return;
+      throw std::runtime_error("'data' is empty");
     }
 
     rmw_message_info_t msg_info;


### PR DESCRIPTION
Now trying to take a message when there's any, provoques just an error to be logged, but the program continues.

In the following image, the output of a pub-sub where the subscription has depth=1 and the publisher publishes several messages before the subscription start spinning, so accumulates events in the queue but there's only one message in the buffer.

In this case there are 4 events in the queue when the subscription starts, so it takes the 1st message but the rest 3 are no-ops.

![image](https://user-images.githubusercontent.com/16389257/106045906-7c07fc80-60d9-11eb-8144-dd618c808e0d.png)
