### PR TITLE
Add QoS bounded queue

### DIFF
--- a/rclcpp/include/rclcpp/executors/events_executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_entities_collector.hpp
@@ -200,6 +200,39 @@ public:
     return nullptr;
   }
 
+  ///
+  /**
+   * Get the subscription qos depth corresponding
+   * to a subscription identifier
+   */
+  RCLCPP_PUBLIC
+  size_t
+  get_subscription_qos_depth(const void * subscription_id);
+
+  ///
+  /**
+   * Get the waitable qos depth corresponding
+   * to a waitable identifier
+   */
+  RCLCPP_PUBLIC
+  size_t
+  get_waitable_qos_depth(const void * waitable_id);
+
+  ///
+  /**
+   * Gets the QoS of this notify waitable.
+   * This is useful for the events executor, when it has to
+   * decide if keep pushing events from this waitable into the qeueue
+   */
+  RCLCPP_PUBLIC
+  rmw_qos_profile_t
+  get_actual_qos() const override
+  {
+    rmw_qos_profile_t qos;
+    qos.depth = 0;
+    return qos;
+  }
+
 private:
   void
   set_callback_group_entities_callbacks(rclcpp::CallbackGroup::SharedPtr group);
@@ -262,6 +295,11 @@ private:
   EventsExecutor * associated_executor_ = nullptr;
   /// Instance of the timers manager used by the associated executor
   TimersManager::SharedPtr timers_manager_;
+
+  // Maps: entity identifiers to qos->depth from the entities registered in the executor
+  using QosDepthMap = std::unordered_map<const void *, size_t>;
+  QosDepthMap qos_depth_subscriptions_map_;
+  QosDepthMap qos_depth_waitables_map_;
 };
 
 }  // namespace executors

--- a/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
@@ -86,6 +86,21 @@ public:
     return nullptr;
   }
 
+  ///
+  /**
+   * Gets the QoS of this notify waitable.
+   * This is useful for the events executor, when it has to
+   * decide if keep pushing events from this waitable into the qeueue
+   */
+  RCLCPP_PUBLIC
+  rmw_qos_profile_t
+  get_actual_qos() const override
+  {
+    rmw_qos_profile_t qos;
+    qos.depth = 0;
+    return qos;
+  }
+
 private:
   std::list<const rcl_guard_condition_t *> notify_guard_conditions_;
 };

--- a/rclcpp/include/rclcpp/experimental/buffers/events_queue.hpp
+++ b/rclcpp/include/rclcpp/experimental/buffers/events_queue.hpp
@@ -89,7 +89,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   void
-  init() = 0;
+  init(rclcpp::executors::EventsExecutorEntitiesCollector::SharedPtr entities_collector) = 0;
 
   /**
    * @brief gets a queue with all events accumulated on it since

--- a/rclcpp/include/rclcpp/experimental/buffers/qos_bounded_events_queue.hpp
+++ b/rclcpp/include/rclcpp/experimental/buffers/qos_bounded_events_queue.hpp
@@ -1,0 +1,288 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__EXPERIMENTAL__BUFFERS__BOUNDED_EVENTS_QUEUE_HPP_
+#define RCLCPP__EXPERIMENTAL__BUFFERS__BOUNDED_EVENTS_QUEUE_HPP_
+
+#include <deque>
+#include <utility>
+
+#include "rclcpp/experimental/buffers/events_queue.hpp"
+
+namespace rclcpp
+{
+namespace experimental
+{
+namespace buffers
+{
+
+/**
+ * @brief This class provides a bounded queue implementation
+ * based on a std::queue. Before pushing events into the queue
+ * checks the queue size. In case of exceeding the size it performs
+ * a prune of the queue.
+ */
+class QosBoundedEventsQueue : public EventsQueue
+{
+public:
+  RCLCPP_PUBLIC
+  explicit QosBoundedEventsQueue(size_t queue_size_limit)
+  {
+    queue_size_limit_ = queue_size_limit;
+  }
+
+  RCLCPP_PUBLIC
+  ~QosBoundedEventsQueue() = default;
+
+  /**
+   * @brief push event into the queue
+   * @param event The event to push into the queue
+   */
+  RCLCPP_PUBLIC
+  virtual
+  void
+  push(const rmw_listener_event_t & event)
+  {
+    event_queue_.push_back(event);
+
+    if (event_queue_.size() >= queue_size_limit_) {
+      prune_queue();
+    }
+  }
+
+  /**
+   * @brief removes front element from the queue
+   * The element removed is the "oldest" element in the queue whose
+   * value can be retrieved by calling member front().
+   */
+  RCLCPP_PUBLIC
+  virtual
+  void
+  pop()
+  {
+    event_queue_.pop_front();
+  }
+
+  /**
+   * @brief gets the front event from the queue
+   * @return the front event
+   */
+  RCLCPP_PUBLIC
+  virtual
+  rmw_listener_event_t
+  front() const
+  {
+    return event_queue_.front();
+  }
+
+  /**
+   * @brief Test whether queue is empty
+   * @return true if the queue's size is 0, false otherwise.
+   */
+  RCLCPP_PUBLIC
+  virtual
+  bool
+  empty() const
+  {
+    return event_queue_.empty();
+  }
+
+  /**
+   * @brief Initializes the queue
+   */
+  RCLCPP_PUBLIC
+  virtual
+  void
+  init(rclcpp::executors::EventsExecutorEntitiesCollector::SharedPtr entities_collector)
+  {
+    // Assign entities collector
+    entities_collector_ = entities_collector;
+
+    // Make sure the queue is empty when we start
+    std::deque<rmw_listener_event_t> emtpy_queue;
+    std::swap(event_queue_, emtpy_queue);
+  }
+
+  /**
+   * @brief gets a queue with all events accumulated on it since
+   * the last call. The member queue is empty when the call returns.
+   * @return std::queue with events
+   */
+  RCLCPP_PUBLIC
+  virtual
+  std::queue<rmw_listener_event_t>
+  get_all_events()
+  {
+    // Initialize a queue with the events in deque
+    std::queue<rmw_listener_event_t> local_queue(
+      std::queue<rmw_listener_event_t>::container_type(
+        event_queue_.begin(), event_queue_.end()));
+
+    // Empty the queue
+    std::deque<rmw_listener_event_t> emtpy_queue;
+    std::swap(event_queue_, emtpy_queue);
+
+    return local_queue;
+  }
+
+private:
+  RCLCPP_PUBLIC
+  void
+  prune_queue()
+  {
+    // Clear maps
+    subscription_events_in_queue_map_.clear();
+    waitable_events_in_queue_map_.clear();
+
+    std::cout << "prune queue" << std::endl;
+
+    // Prune queue:
+    // For each entity, we get its QoS depth and use it as its events limit.
+    // Starting from the newer events (backward iterating the queue) we
+    // count events from each entity. If there are more events than the limit,
+    // we discard the oldest events. The
+    // For example, subscription A has depth = 1 / B has depth = 2
+    //                           C has depth = 1 / D has depth = 1
+    // If the queue is:
+    //  Older Events (front of the queue)
+    //    | D |
+    //    | A | -> Should be removed, the msg has expired and overriden.
+    //    | A | -> Should be removed
+    //    | B | -> Should be removed        | D |
+    //    | C |                             | C |
+    //    | B |                             | B |
+    //    | A |           --->              | A |
+    //    | B |                             | B |
+    //  Newer Events                    After pruning
+    //
+    // Even with this prunning method, after pruning we might still have more events
+    // in the queue than the limit set on the queue, if for example a subscription has a
+    // qos->depth bigger than the queue limit, and all the messages in the queue
+    // belonged to that subscription
+    std::deque<rmw_listener_event_t>::reverse_iterator rit = event_queue_.rbegin();
+
+    while (rit != event_queue_.rend()) {
+      auto event = *rit;
+
+      switch (event.type) {
+        case SUBSCRIPTION_EVENT:
+          {
+            bool limit_reached = subscription_events_reached_limit(event.entity);
+
+            if (limit_reached) {
+              // Remove oldest events
+              rit = decltype(rit)(event_queue_.erase(std::next(rit).base()));
+            } else {
+              rit++;
+            }
+            break;
+          }
+
+        case SERVICE_EVENT:
+        case CLIENT_EVENT:
+          {
+            break;
+          }
+
+        case WAITABLE_EVENT:
+          {
+            bool limit_reached = waitable_events_reached_limit(event.entity);
+
+            if (limit_reached) {
+              // Remove oldest events
+              rit = decltype(rit)(event_queue_.erase(std::next(rit).base()));
+            } else {
+              rit++;
+            }
+            break;
+          }
+      }
+    }
+  }
+
+  bool subscription_events_reached_limit(const void * subscription_id)
+  {
+    size_t limit = entities_collector_->get_subscription_qos_depth(subscription_id);
+
+    // If there's no limit, return false
+    if (!limit) {
+      return false;
+    }
+
+    auto it = subscription_events_in_queue_map_.find(subscription_id);
+
+    if (it != subscription_events_in_queue_map_.end()) {
+      size_t & subscription_events_in_queue = it->second;
+
+      if (subscription_events_in_queue < limit) {
+        // Add one event as we still didn't reach the limit
+        subscription_events_in_queue++;
+        return false;
+      } else {
+        return true;
+      }
+    }
+
+    // If the subscription_id is not present in the map, add it with one event in the counter
+    subscription_events_in_queue_map_.emplace(subscription_id, 1);
+    return false;
+  }
+
+  bool waitable_events_reached_limit(const void * waitable_id)
+  {
+    auto limit = entities_collector_->get_waitable_qos_depth(waitable_id);
+
+    // If there's no limit, return false
+    if (!limit) {
+      return false;
+    }
+
+    auto it = waitable_events_in_queue_map_.find(waitable_id);
+
+    if (it != waitable_events_in_queue_map_.end()) {
+      size_t & waitable_events_in_queue = it->second;
+
+      if (waitable_events_in_queue < limit) {
+        // Add one event as we still didn't reach the limit
+        waitable_events_in_queue++;
+        return false;
+      } else {
+        return true;
+      }
+    }
+
+    // If the waitable_id is not present in the map, add it with one event in the counter
+    waitable_events_in_queue_map_.emplace(waitable_id, 1);
+    return false;
+  }
+
+  // Variables
+  std::deque<rmw_listener_event_t> event_queue_;
+  size_t queue_size_limit_;
+
+  // Maps: entity identifiers to number of events in the queue
+  using EventsInQueueMap = std::unordered_map<const void *, size_t>;
+  EventsInQueueMap subscription_events_in_queue_map_;
+  EventsInQueueMap waitable_events_in_queue_map_;
+
+  // Entities collector associated with executor and events queue
+  rclcpp::executors::EventsExecutorEntitiesCollector::SharedPtr entities_collector_;
+};
+
+}  // namespace buffers
+}  // namespace experimental
+}  // namespace rclcpp
+
+
+#endif  // RCLCPP__EXPERIMENTAL__BUFFERS__BOUNDED_EVENTS_QUEUE_HPP_

--- a/rclcpp/include/rclcpp/experimental/buffers/simple_events_queue.hpp
+++ b/rclcpp/include/rclcpp/experimental/buffers/simple_events_queue.hpp
@@ -95,8 +95,9 @@ public:
   RCLCPP_PUBLIC
   virtual
   void
-  init()
+  init(rclcpp::executors::EventsExecutorEntitiesCollector::SharedPtr entities_collector)
   {
+    (void)entities_collector;
     // Make sure the queue is empty when we start
     std::queue<rmw_listener_event_t> local_queue;
     std::swap(event_queue_, local_queue);

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -114,6 +114,11 @@ public:
     const rclcpp::executors::EventsExecutor * executor,
     rmw_listener_callback_t executor_callback) const override;
 
+  RCLCPP_PUBLIC
+  virtual
+  rmw_qos_profile_t
+  get_actual_qos() const override;
+
 protected:
   rcl_event_t event_handle_;
   size_t wait_set_event_index_;

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -215,6 +215,11 @@ public:
     const rclcpp::executors::EventsExecutor * executor,
     rmw_listener_callback_t executor_callback) const;
 
+  RCLCPP_PUBLIC
+  virtual
+  rmw_qos_profile_t
+  get_actual_qos() const;
+
 private:
   std::atomic<bool> in_use_by_wait_set_{false};
 };  // class Waitable

--- a/rclcpp/src/rclcpp/executors/events_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/events_executor.cpp
@@ -46,7 +46,7 @@ EventsExecutor::EventsExecutor(
   // Get ownership of the queue used to store events.
   events_queue_ = std::move(events_queue);
   // Init the events queue
-  events_queue_->init();
+  events_queue_->init(entities_collector_);
 }
 
 void

--- a/rclcpp/src/rclcpp/executors/events_executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/events_executor_entities_collector.cpp
@@ -77,6 +77,8 @@ EventsExecutorEntitiesCollector::~EventsExecutorEntitiesCollector()
   weak_services_map_.clear();
   weak_waitables_map_.clear();
   weak_subscriptions_map_.clear();
+  qos_depth_waitables_map_.clear();
+  qos_depth_subscriptions_map_.clear();
   weak_nodes_to_guard_conditions_.clear();
   weak_groups_associated_with_executor_to_nodes_.clear();
   weak_groups_to_nodes_associated_with_executor_.clear();
@@ -234,9 +236,13 @@ EventsExecutorEntitiesCollector::set_callback_group_entities_callbacks(
   group->find_subscription_ptrs_if(
     [this](const rclcpp::SubscriptionBase::SharedPtr & subscription) {
       if (subscription) {
+        qos_depth_subscriptions_map_.emplace(
+          subscription.get(), subscription->get_actual_qos().depth());
+
         subscription->set_events_executor_callback(
           associated_executor_,
           &EventsExecutor::push_event);
+
         weak_subscriptions_map_.emplace(subscription.get(), subscription);
       }
       return false;
@@ -264,9 +270,13 @@ EventsExecutorEntitiesCollector::set_callback_group_entities_callbacks(
   group->find_waitable_ptrs_if(
     [this](const rclcpp::Waitable::SharedPtr & waitable) {
       if (waitable) {
+        qos_depth_waitables_map_.emplace(
+          waitable.get(), waitable->get_actual_qos().depth);
+
         waitable->set_events_executor_callback(
           associated_executor_,
           &EventsExecutor::push_event);
+
         weak_waitables_map_.emplace(waitable.get(), waitable);
       }
       return false;
@@ -292,6 +302,7 @@ EventsExecutorEntitiesCollector::unset_callback_group_entities_callbacks(
       if (subscription) {
         subscription->set_events_executor_callback(nullptr, nullptr);
         weak_subscriptions_map_.erase(subscription.get());
+        qos_depth_subscriptions_map_.erase(subscription.get());
       }
       return false;
     });
@@ -316,6 +327,7 @@ EventsExecutorEntitiesCollector::unset_callback_group_entities_callbacks(
       if (waitable) {
         waitable->set_events_executor_callback(nullptr, nullptr);
         weak_waitables_map_.erase(waitable.get());
+        qos_depth_waitables_map_.erase(waitable.get());
       }
       return false;
     });
@@ -520,6 +532,7 @@ EventsExecutorEntitiesCollector::get_subscription(const void * subscription_id)
 
     // The subscription expired, remove from map
     weak_subscriptions_map_.erase(it);
+    qos_depth_subscriptions_map_.erase(subscription_id);
   }
   return nullptr;
 }
@@ -577,6 +590,7 @@ EventsExecutorEntitiesCollector::get_waitable(const void * waitable_id)
 
     // The waitable expired, remove from map
     weak_waitables_map_.erase(it);
+    qos_depth_waitables_map_.erase(waitable_id);
   }
   return nullptr;
 }
@@ -584,5 +598,34 @@ EventsExecutorEntitiesCollector::get_waitable(const void * waitable_id)
 void
 EventsExecutorEntitiesCollector::add_waitable(rclcpp::Waitable::SharedPtr waitable)
 {
+  qos_depth_waitables_map_.emplace(waitable.get(), waitable->get_actual_qos().depth);
   weak_waitables_map_.emplace(waitable.get(), waitable);
+}
+
+size_t
+EventsExecutorEntitiesCollector::get_subscription_qos_depth(const void * subscription_id)
+{
+  auto it = qos_depth_subscriptions_map_.find(subscription_id);
+
+  if (it != qos_depth_subscriptions_map_.end()) {
+    size_t qos_depth = it->second;
+    return qos_depth;
+  }
+
+  // If the subscription_id is not present in the map, throw error
+  throw std::runtime_error("Event from subscription not registered in map!");
+}
+
+size_t
+EventsExecutorEntitiesCollector::get_waitable_qos_depth(const void * waitable_id)
+{
+  auto it = qos_depth_waitables_map_.find(waitable_id);
+
+  if (it != qos_depth_waitables_map_.end()) {
+    size_t qos_depth = it->second;
+    return qos_depth;
+  }
+
+  // If the waitable_id is not present in the map, throw error
+  throw std::runtime_error("Event from waitable not registered in map!");
 }

--- a/rclcpp/src/rclcpp/qos_event.cpp
+++ b/rclcpp/src/rclcpp/qos_event.cpp
@@ -85,4 +85,12 @@ QOSEventHandlerBase::set_events_executor_callback(
   }
 }
 
+rmw_qos_profile_t
+QOSEventHandlerBase::get_actual_qos() const
+{
+  rmw_qos_profile_t qos;
+  qos.depth = 0;
+  return qos;
+}
+
 }  // namespace rclcpp

--- a/rclcpp/src/rclcpp/waitable.cpp
+++ b/rclcpp/src/rclcpp/waitable.cpp
@@ -71,3 +71,10 @@ Waitable::set_events_executor_callback(
   throw std::runtime_error(
           "Custom waitables should override set_events_executor_callback() to use events executor");
 }
+
+rmw_qos_profile_t
+Waitable::get_actual_qos() const
+{
+  throw std::runtime_error(
+          "Custom waitables should override get_actual_qos() to use events executor");
+}


### PR DESCRIPTION
This PR is not intended to be merged, but could be useful for discussing a bounded queue design & implementation.

This QoS bounded queue has a limit set on construction, for example 100 elements. When we surpase this limit, we prune the queue.

The pruning is based on the QoS->depth of each entity event in the queue, so if we had for example 20 events from an entity with QoS->depth=10, we remove the 10 oldest events.
This implies having QoS->depth defined for each entity, as Waitables, which is not conceptually correct. 
Also we need new APIs to map each entity with their depths.

After pruning, we might still have more events in the queue than the limit set, if the QoS->depth of an entity is bigger than the queue limit.

If we don't take into account the QoS->depth of each entity, and for example we prune the queue by removing all elements, we'll be behind the DDS queues (like IPC ring buffer) and new events will retrieve older messages. So in order to prune the queue without taking into account QoS, we should be able to also prune the DDS internal queues.