### PR TITLE
remove smart pointer definitions for virtual class

### DIFF
--- a/rclcpp/include/rclcpp/executors/event_waitable.hpp
+++ b/rclcpp/include/rclcpp/executors/event_waitable.hpp
@@ -33,8 +33,6 @@ namespace executors
 class EventWaitable : public rclcpp::Waitable
 {
 public:
-  RCLCPP_SMART_PTR_DEFINITIONS(EventWaitable)
-
   // Constructor
   RCLCPP_PUBLIC
   EventWaitable() = default;


### PR DESCRIPTION
Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>

This smart pointer definition caused a compilation error when building with clang 7, due to event waitable class being pure virtual (it inerhits from pure virtual waitable and does not implement execute)

any reason to keep it @mauropasse ?