### PR TITLE
Asoragna/cleanup

### DIFF
--- a/rclcpp/include/rclcpp/executors/timers_manager.hpp
+++ b/rclcpp/include/rclcpp/executors/timers_manager.hpp
@@ -65,7 +65,7 @@ public:
 
   /**
    * @brief Construct a new TimersManager object
-   * 
+   *
    * @param context custom context to be used.
    * Shared ownership of the context is held until destruction.
    */
@@ -79,7 +79,7 @@ public:
   /**
    * @brief Adds a new timer to the storage, maintaining weak ownership of it.
    * Function is thread safe and it can be called regardless of the state of the timers thread.
-   * 
+   *
    * @param timer the timer to add.
    */
   void add_timer(rclcpp::TimerBase::SharedPtr timer);
@@ -88,7 +88,7 @@ public:
    * @brief Remove a single timer from the object storage.
    * Will do nothing if the timer was not being stored here.
    * Function is thread safe and it can be called regardless of the state of the timers thread.
-   * 
+   *
    * @param timer the timer to remove.
    */
   void remove_timer(rclcpp::TimerBase::SharedPtr timer);
@@ -121,7 +121,7 @@ public:
   /**
    * @brief Executes head timer if ready at time point.
    * Function is thread safe, but it will throw an error if the timers thread is running.
-   * 
+   *
    * @param tp the time point to check for, where `max()` denotes that no check will be performed.
    * @return true if head timer was ready at time point.
    */
@@ -132,7 +132,7 @@ public:
   /**
    * @brief Get the amount of time before the next timer expires.
    * Function is thread safe, but it will throw an error if the timers thread is running.
-   * 
+   *
    * @return std::chrono::nanoseconds to wait,
    * the returned value could be negative if the timer is already expired
    * or MAX_TIME if there are no timers stored in the object.
@@ -204,9 +204,25 @@ public:
     }
 
     /**
+     * @brief Returns a const reference to the front element
+     */
+    const WeakTimerPtr & front() const
+    {
+      return weak_heap_.front();
+    }
+
+    /**
+     * @brief Returns whether the heap is empty or not
+     */
+    bool empty() const
+    {
+      return weak_heap_.empty();
+    }
+
+    /**
      * @brief This function restores the current object as a valid heap
      * and it returns a locked version of it.
-     * It is the only public API to access the stored timers.
+     * It is the only public API to access and manipulate the stored timers.
      *
      * @return TimersHeap owned timers corresponding to the current object
      */
@@ -411,13 +427,7 @@ private:
    * or MAX_TIME if the heap is empty.
    * This function is not thread safe, acquire the timers_mutex_ before calling it.
    */
-  std::chrono::nanoseconds get_head_timeout_unsafe(const TimersHeap & heap)
-  {
-    if (heap.empty()) {
-      return MAX_TIME;
-    }
-    return (heap.front())->time_until_trigger();
-  }
+  std::chrono::nanoseconds get_head_timeout_unsafe();
 
   /**
    * @brief Executes all the timers currently ready when the function is invoked

--- a/rclcpp/include/rclcpp/experimental/buffers/events_queue.hpp
+++ b/rclcpp/include/rclcpp/experimental/buffers/events_queue.hpp
@@ -17,8 +17,8 @@
 
 #include <queue>
 
-#include "rclcpp/executors/events_executor_entities_collector.hpp"
 #include "rclcpp/macros.hpp"
+#include "rclcpp/visibility_control.hpp"
 
 #include "rmw/listener_event_types.h"
 
@@ -30,10 +30,14 @@ namespace buffers
 {
 
 /**
- * @brief This abstract class is intended to be used as
- * a wrapper around a queue. The derived classes should chose
- * which container to use and the strategies for push and prune
- * events from the queue.
+ * @brief This abstract class can be used to implement different types of queues
+ * where `rmw_listener_event_t` can be stored.
+ * The derived classes should choose which underlying container to use and
+ * the strategy for pushing and popping events.
+ * For example a queue implementation may be bounded or unbounded and have
+ * different pruning strategies.
+ * Implementations may or may not check the validity of events and decide how to handle
+ * the situation where an event is not valid anymore (e.g. a subscription history cache overruns)
  */
 class EventsQueue
 {
@@ -56,9 +60,7 @@ public:
   push(const rmw_listener_event_t & event) = 0;
 
   /**
-   * @brief removes front element from the queue
-   * The element removed is the "oldest" element in the queue whose
-   * value can be retrieved by calling member front().
+   * @brief removes front element from the queue.
    */
   RCLCPP_PUBLIC
   virtual
@@ -101,14 +103,13 @@ public:
   init() = 0;
 
   /**
-   * @brief gets a queue with all events accumulated on it since
-   * the last call. The member queue is empty when the call returns.
+   * @brief pops out all events stored in the object into an output queue.
    * @return queue with events
    */
   RCLCPP_PUBLIC
   virtual
   std::queue<rmw_listener_event_t>
-  get_all_events() = 0;
+  pop_all_events() = 0;
 };
 
 }  // namespace buffers

--- a/rclcpp/include/rclcpp/experimental/buffers/simple_events_queue.hpp
+++ b/rclcpp/include/rclcpp/experimental/buffers/simple_events_queue.hpp
@@ -28,11 +28,10 @@ namespace buffers
 {
 
 /**
- * @brief This class provides a simple queue implementation
- * based on a std::queue. As the objective is having a CPU peformant
- * queue, it does not performs any checks about the size of
- * the queue, so the queue size could grow unbounded.
- * It does not implement any pruning mechanisms.
+ * @brief This class implements an EventsQueue as a simple wrapper around a std::queue.
+ * It does not perform any checks about the size of queue, which can grow
+ * unbounded without being pruned.
+ * The simplicity of this implementation makes it suitable for optimizing CPU usage.
  */
 class SimpleEventsQueue : public EventsQueue
 {
@@ -53,9 +52,7 @@ public:
   }
 
   /**
-   * @brief removes front element from the queue
-   * The element removed is the "oldest" element in the queue whose
-   * value can be retrieved by calling member front().
+   * @brief removes front event from the queue.
    */
   RCLCPP_PUBLIC
   virtual
@@ -114,7 +111,6 @@ public:
     std::swap(event_queue_, local_queue);
   }
 
-
   /**
    * @brief gets a queue with all events accumulated on it since
    * the last call. The member queue is empty when the call returns.
@@ -123,7 +119,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   std::queue<rmw_listener_event_t>
-  get_all_events()
+  pop_all_events()
   {
     std::queue<rmw_listener_event_t> local_queue;
     std::swap(event_queue_, local_queue);

--- a/rclcpp/test/rclcpp/executors/test_events_queue.cpp
+++ b/rclcpp/test/rclcpp/executors/test_events_queue.cpp
@@ -21,21 +21,7 @@
 
 using namespace std::chrono_literals;
 
-class TestEventsQueue : public ::testing::Test
-{
-public:
-  void SetUp()
-  {
-    rclcpp::init(0, nullptr);
-  }
-
-  void TearDown()
-  {
-    rclcpp::shutdown();
-  }
-};
-
-TEST_F(TestEventsQueue, SimpleQueueTest)
+TEST(TestEventsQueue, SimpleQueueTest)
 {
   // Create a SimpleEventsQueue and a local queue
   auto simple_queue = std::make_unique<rclcpp::experimental::buffers::SimpleEventsQueue>();
@@ -54,7 +40,7 @@ TEST_F(TestEventsQueue, SimpleQueueTest)
   // Pop one message
   simple_queue->pop();
 
-  local_events_queue = simple_queue->get_all_events();
+  local_events_queue = simple_queue->pop_all_events();
 
   // We should have (11 - 1) events in the local queue
   size_t local_queue_size = local_events_queue.size();


### PR DESCRIPTION
This PR does some cleanup and small fixes to events executor and timers manager.|

**I suggest to first review by commit**

 - 191f47a3183c1263b5b8efb4ae1294c2c0b5d66c
    - improve doxygen documentation in events executor by removing references to waitset and direct comparisons with other executors;
    - remove using EventQueue as ambiguous due to the presence of EventsQueue class
    - remove consume_all_events function and just move the code there into the only location where the function was called
    - rename get_all_events to pop_all_events to emphatise that the events queue will be empty after that
    
 - 6a99496bb8e32837a46a3eea986e506a23bab52f
     - rework constructor of events executor by: checking that the events queue is not a null pointer and initialize events_queue_ member variable before the entities collector as otherwise there will be a race condition if an event arrives.
     
 - c99d764cfd19f8dd5b7163148440a7c2072f8b64
    - improve doxygen in timers manager, for example not mention heap in public APIs since it's an implementation detail
    - execute_ready_timers now returns void since its return value is not needed anymore (and it was an optimization hack)
    - add friend declaration to timers heap to allow validate_and_lock to access underlying container rather than exposing a public push_back API
       
  - b72d124af12182070e9b4907cab660854b2cddf0
     - The previous implementation had an issue because in `run_timers` it was computing the next timeout at the end of the while loop. This was done because in that location it was possible to directly access the locked heap structure.
     This works only if the next iteration of the while loop is immediately executed, but it will be incorrect if someone else acquires the mutex (e.g. for adding/removing timers).
     The reason is that the next timeout may be 1 second, but maybe the mutex has been held by someone else for 0.8 seconds: the real timeout is now 0.2 seconds, but the previous implementation would have still waited for 1 second.
     The solution is to compute the timeout at the beginning of the while loop, i.e. after the mutex has been acquired.
     In order to do that efficiently I created a new implementation of `get_head_timeout_unsafe` that if no timers have been removed can directly return the timeout without need to iterate over the all vector.