### PR TITLE
Rework executor callback data

### DIFF
--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -158,9 +158,9 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_events_executor_callback(
-    rmw_listener_callback_t executor_callback,
-    const void * executor_callback_data) const;
+  set_listener_callback(
+    rmw_listener_callback_t callback,
+    const void * user_data) const;
 
 protected:
   RCLCPP_DISABLE_COPY(ClientBase)

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -159,8 +159,8 @@ public:
   RCLCPP_PUBLIC
   void
   set_events_executor_callback(
-    rclcpp::executors::EventsExecutor * executor,
-    rmw_listener_callback_t executor_callback) const;
+    rmw_listener_callback_t executor_callback,
+    const void * executor_callback_data) const;
 
 protected:
   RCLCPP_DISABLE_COPY(ClientBase)

--- a/rclcpp/include/rclcpp/executors/events_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor.hpp
@@ -29,7 +29,7 @@
 #include "rclcpp/experimental/buffers/simple_events_queue.hpp"
 #include "rclcpp/node.hpp"
 
-#include "rmw/listener_event_types.h"
+#include "rmw/listener_callback_type.h"
 
 namespace rclcpp
 {

--- a/rclcpp/include/rclcpp/executors/events_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor.hpp
@@ -22,6 +22,7 @@
 
 #include "rclcpp/executor.hpp"
 #include "rclcpp/executors/events_executor_entities_collector.hpp"
+#include "rclcpp/executors/events_executor_event_types.hpp"
 #include "rclcpp/executors/events_executor_notify_waitable.hpp"
 #include "rclcpp/executors/timers_manager.hpp"
 #include "rclcpp/experimental/buffers/events_queue.hpp"
@@ -214,20 +215,20 @@ private:
   // This function is called by the DDS entities when an event happened,
   // like a subscription receiving a message.
   static void
-  push_event(void * executor_ptr, rmw_listener_event_t event)
+  push_event(const void * event_data)
   {
-    // Check if the executor pointer is not valid
-    if (!executor_ptr) {
-      throw std::runtime_error("The executor pointer is not valid.");
+    if (!event_data) {
+      throw std::runtime_error("Executor event data not valid.");
     }
 
-    auto this_executor = static_cast<executors::EventsExecutor *>(executor_ptr);
+    auto data = static_cast<const executors::EventsExecutorCallbackData *>(event_data);
+
+    executors::EventsExecutor * this_executor = data->executor;
 
     // Event queue mutex scope
     {
       std::unique_lock<std::mutex> lock(this_executor->push_mutex_);
-
-      this_executor->events_queue_->push(event);
+      this_executor->events_queue_->push({data->entity_id, data->event_type});
     }
     // Notify that the event queue has some events in it.
     this_executor->events_queue_cv_.notify_one();
@@ -236,7 +237,7 @@ private:
   // Execute a single event
   RCLCPP_PUBLIC
   void
-  execute_event(const rmw_listener_event_t & event);
+  execute_event(const ExecutorEvent & event);
 
   // Queue where entities can push events
   rclcpp::experimental::buffers::EventsQueue::SharedPtr events_queue_;

--- a/rclcpp/include/rclcpp/executors/events_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor.hpp
@@ -228,7 +228,7 @@ private:
     // Event queue mutex scope
     {
       std::unique_lock<std::mutex> lock(this_executor->push_mutex_);
-      this_executor->events_queue_->push({data->entity_id, data->event_type});
+      this_executor->events_queue_->push(data->event);
     }
     // Notify that the event queue has some events in it.
     this_executor->events_queue_cv_.notify_one();

--- a/rclcpp/include/rclcpp/executors/events_executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_entities_collector.hpp
@@ -269,7 +269,16 @@ private:
   EventsExecutor * associated_executor_ = nullptr;
   /// Instance of the timers manager used by the associated executor
   TimersManager::SharedPtr timers_manager_;
-  /// Callback data from entities mapped to a counter of each
+
+  /// Callback data objects mapped to the number of listeners sharing the same object.
+  /// When no more listeners use the object, it can be removed from the map.
+  /// For example, the entities collector holds every node's guard condition, which
+  /// share the same EventsExecutorCallbackData object ptr to use as their callback arg:
+  ///    cb_data_object = {executor_ptr, entities_collector_ptr, WAITABLE_EVENT};
+  ///    Node1->gc(&cb_data_object)
+  ///    Node2->gc(&cb_data_object)
+  /// So the maps has: (cb_data_object, 2)
+  /// When both nodes are removed (counter = 0), the cb_data_object can be destroyed.
   std::unordered_map<EventsExecutorCallbackData, size_t, KeyHasher> callback_data_map_;
 };
 

--- a/rclcpp/include/rclcpp/executors/events_executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_entities_collector.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "rclcpp/executors/event_waitable.hpp"
+#include "rclcpp/executors/events_executor_event_types.hpp"
 #include "rclcpp/executors/timers_manager.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 
@@ -213,6 +214,12 @@ private:
   void
   unset_guard_condition_callback(const rcl_guard_condition_t * guard_condition);
 
+  void
+  remove_callback_data(void * entity_id, ExecutorEventType type);
+
+  const EventsExecutorCallbackData *
+  get_callback_data(void * entity_id, ExecutorEventType type);
+
   /// Return true if the node belongs to the collector
   /**
    * \param[in] group_ptr a node base interface shared pointer
@@ -262,6 +269,8 @@ private:
   EventsExecutor * associated_executor_ = nullptr;
   /// Instance of the timers manager used by the associated executor
   TimersManager::SharedPtr timers_manager_;
+  /// Callback data from entities mapped to a counter of each
+  std::unordered_map<EventsExecutorCallbackData, size_t, KeyHasher> callback_data_map_;
 };
 
 }  // namespace executors

--- a/rclcpp/include/rclcpp/executors/events_executor_event_types.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_event_types.hpp
@@ -37,16 +37,20 @@ struct ExecutorEvent
   ExecutorEventType type;
 };
 
+// The EventsExecutorCallbackData struct is what the listeners
+// will use as argument when calling their callbacks from the
+// RMW implementation. The listeners get a (void *) of this struct,
+// and the executor is in charge to cast it back and use the data.
 struct EventsExecutorCallbackData
 {
   EventsExecutorCallbackData(
-    EventsExecutor * exec,
-    void * id,
-    ExecutorEventType type)
+    EventsExecutor * _executor,
+    void * _entity_id,
+    ExecutorEventType _event_type)
   {
-    executor = exec;
-    entity_id = id;
-    event_type = type;
+    executor = _executor;
+    entity_id = _entity_id;
+    event_type = _event_type;
   }
 
   // Equal operator
@@ -64,14 +68,13 @@ struct EventsExecutorCallbackData
 };
 
 // To be able to use std::unordered_map with an EventsExecutorCallbackData
-// as key, we need a hasher:
+// as key, we need a hasher. We use the entity ID as hash, since it is
+// unique for each EventsExecutorCallbackData object.
 struct KeyHasher
 {
-  size_t operator()(const EventsExecutorCallbackData & k) const
+  size_t operator()(const EventsExecutorCallbackData & key) const
   {
-    return ((std::hash<EventsExecutor *>()(k.executor) ^
-           (std::hash<void *>()(k.entity_id) << 1)) >> 1) ^
-           (std::hash<ExecutorEventType>()(k.event_type) << 1);
+    return std::hash<EventsExecutor *>()(key.entity_id);
   }
 };
 

--- a/rclcpp/include/rclcpp/executors/events_executor_event_types.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_event_types.hpp
@@ -45,26 +45,21 @@ struct EventsExecutorCallbackData
 {
   EventsExecutorCallbackData(
     EventsExecutor * _executor,
-    void * _entity_id,
-    ExecutorEventType _event_type)
+    ExecutorEvent _event)
   {
     executor = _executor;
-    entity_id = _entity_id;
-    event_type = _event_type;
+    event = _event;
   }
 
   // Equal operator
   bool operator==(const EventsExecutorCallbackData & other) const
   {
-    return (executor == other.executor) &&
-           (entity_id == other.entity_id) &&
-           (event_type == other.event_type);
+    return (event.entity_id == other.event.entity_id);
   }
 
   // Struct members
   EventsExecutor * executor;
-  void * entity_id;
-  ExecutorEventType event_type;
+  ExecutorEvent event;
 };
 
 // To be able to use std::unordered_map with an EventsExecutorCallbackData
@@ -74,7 +69,7 @@ struct KeyHasher
 {
   size_t operator()(const EventsExecutorCallbackData & key) const
   {
-    return std::hash<void *>()(key.entity_id);
+    return std::hash<const void *>()(key.event.entity_id);
   }
 };
 

--- a/rclcpp/include/rclcpp/executors/events_executor_event_types.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_event_types.hpp
@@ -74,7 +74,7 @@ struct KeyHasher
 {
   size_t operator()(const EventsExecutorCallbackData & key) const
   {
-    return std::hash<EventsExecutor *>()(key.entity_id);
+    return std::hash<void *>()(key.entity_id);
   }
 };
 

--- a/rclcpp/include/rclcpp/executors/events_executor_event_types.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_event_types.hpp
@@ -1,0 +1,81 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__EXECUTORS__EVENTS_EXECUTOR_EVENT_TYPES_HPP_
+#define RCLCPP__EXECUTORS__EVENTS_EXECUTOR_EVENT_TYPES_HPP_
+
+namespace rclcpp
+{
+namespace executors
+{
+
+// forward declaration of EventsExecutor to avoid circular dependency
+class EventsExecutor;
+
+enum ExecutorEventType
+{
+  SUBSCRIPTION_EVENT,
+  SERVICE_EVENT,
+  CLIENT_EVENT,
+  WAITABLE_EVENT
+};
+
+struct ExecutorEvent
+{
+  const void * entity_id;
+  ExecutorEventType type;
+};
+
+struct EventsExecutorCallbackData
+{
+  EventsExecutorCallbackData(
+    EventsExecutor * exec,
+    void * id,
+    ExecutorEventType type)
+  {
+    executor = exec;
+    entity_id = id;
+    event_type = type;
+  }
+
+  // Equal operator
+  bool operator==(const EventsExecutorCallbackData & other) const
+  {
+    return (executor == other.executor) &&
+           (entity_id == other.entity_id) &&
+           (event_type == other.event_type);
+  }
+
+  // Struct members
+  EventsExecutor * executor;
+  void * entity_id;
+  ExecutorEventType event_type;
+};
+
+// To be able to use std::unordered_map with an EventsExecutorCallbackData
+// as key, we need a hasher:
+struct KeyHasher
+{
+  size_t operator()(const EventsExecutorCallbackData & k) const
+  {
+    return ((std::hash<EventsExecutor *>()(k.executor) ^
+           (std::hash<void *>()(k.entity_id) << 1)) >> 1) ^
+           (std::hash<ExecutorEventType>()(k.event_type) << 1);
+  }
+};
+
+}  // namespace executors
+}  // namespace rclcpp
+
+#endif  // RCLCPP__EXECUTORS__EVENTS_EXECUTOR_EVENT_TYPES_HPP_

--- a/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
@@ -61,15 +61,14 @@ public:
   RCLCPP_PUBLIC
   void
   set_events_executor_callback(
-    rclcpp::executors::EventsExecutor * executor,
-    rmw_listener_callback_t executor_callback) const override
+    rmw_listener_callback_t executor_callback,
+    const void * executor_callback_data) const override
   {
     for (auto gc : notify_guard_conditions_) {
       rcl_ret_t ret = rcl_guard_condition_set_listener_callback(
         gc,
         executor_callback,
-        executor,
-        this,
+        executor_callback_data,
         false);
 
       if (RCL_RET_OK != ret) {

--- a/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
@@ -60,15 +60,15 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_events_executor_callback(
-    rmw_listener_callback_t executor_callback,
-    const void * executor_callback_data) const override
+  set_listener_callback(
+    rmw_listener_callback_t callback,
+    const void * user_data) const override
   {
     for (auto gc : notify_guard_conditions_) {
       rcl_ret_t ret = rcl_guard_condition_set_listener_callback(
         gc,
-        executor_callback,
-        executor_callback_data,
+        callback,
+        user_data,
         false);
 
       if (RCL_RET_OK != ret) {

--- a/rclcpp/include/rclcpp/experimental/buffers/events_queue.hpp
+++ b/rclcpp/include/rclcpp/experimental/buffers/events_queue.hpp
@@ -42,7 +42,7 @@ namespace buffers
 class EventsQueue
 {
 public:
-  RCLCPP_SMART_PTR_DEFINITIONS(EventsQueue)
+  RCLCPP_SMART_PTR_ALIASES_ONLY(EventsQueue)
 
   /**
    * @brief Destruct the object.

--- a/rclcpp/include/rclcpp/experimental/buffers/events_queue.hpp
+++ b/rclcpp/include/rclcpp/experimental/buffers/events_queue.hpp
@@ -20,7 +20,7 @@
 #include "rclcpp/macros.hpp"
 #include "rclcpp/visibility_control.hpp"
 
-#include "rmw/listener_event_types.h"
+#include "rclcpp/executors/events_executor_event_types.hpp"
 
 namespace rclcpp
 {
@@ -31,7 +31,7 @@ namespace buffers
 
 /**
  * @brief This abstract class can be used to implement different types of queues
- * where `rmw_listener_event_t` can be stored.
+ * where `ExecutorEvent` can be stored.
  * The derived classes should choose which underlying container to use and
  * the strategy for pushing and popping events.
  * For example a queue implementation may be bounded or unbounded and have
@@ -57,7 +57,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   void
-  push(const rmw_listener_event_t & event) = 0;
+  push(const rclcpp::executors::ExecutorEvent & event) = 0;
 
   /**
    * @brief removes front element from the queue.
@@ -73,7 +73,7 @@ public:
    */
   RCLCPP_PUBLIC
   virtual
-  rmw_listener_event_t
+  rclcpp::executors::ExecutorEvent
   front() const = 0;
 
   /**
@@ -108,7 +108,7 @@ public:
    */
   RCLCPP_PUBLIC
   virtual
-  std::queue<rmw_listener_event_t>
+  std::queue<rclcpp::executors::ExecutorEvent>
   pop_all_events() = 0;
 };
 

--- a/rclcpp/include/rclcpp/experimental/buffers/simple_events_queue.hpp
+++ b/rclcpp/include/rclcpp/experimental/buffers/simple_events_queue.hpp
@@ -46,7 +46,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   void
-  push(const rmw_listener_event_t & event)
+  push(const rclcpp::executors::ExecutorEvent & event)
   {
     event_queue_.push(event);
   }
@@ -68,7 +68,7 @@ public:
    */
   RCLCPP_PUBLIC
   virtual
-  rmw_listener_event_t
+  rclcpp::executors::ExecutorEvent
   front() const
   {
     return event_queue_.front();
@@ -107,7 +107,7 @@ public:
   init()
   {
     // Make sure the queue is empty when we start
-    std::queue<rmw_listener_event_t> local_queue;
+    std::queue<rclcpp::executors::ExecutorEvent> local_queue;
     std::swap(event_queue_, local_queue);
   }
 
@@ -118,16 +118,16 @@ public:
    */
   RCLCPP_PUBLIC
   virtual
-  std::queue<rmw_listener_event_t>
+  std::queue<rclcpp::executors::ExecutorEvent>
   pop_all_events()
   {
-    std::queue<rmw_listener_event_t> local_queue;
+    std::queue<rclcpp::executors::ExecutorEvent> local_queue;
     std::swap(event_queue_, local_queue);
     return local_queue;
   }
 
 private:
-  std::queue<rmw_listener_event_t> event_queue_;
+  std::queue<rclcpp::executors::ExecutorEvent> event_queue_;
 };
 
 }  // namespace buffers

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -76,9 +76,9 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_events_executor_callback(
-    rmw_listener_callback_t executor_callback,
-    const void * executor_callback_data) const override;
+  set_listener_callback(
+    rmw_listener_callback_t callback,
+    const void * user_data) const override;
 
 protected:
   std::recursive_mutex reentrant_mutex_;

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -77,8 +77,8 @@ public:
   RCLCPP_PUBLIC
   void
   set_events_executor_callback(
-    rclcpp::executors::EventsExecutor * executor,
-    rmw_listener_callback_t executor_callback) const override;
+    rmw_listener_callback_t executor_callback,
+    const void * executor_callback_data) const override;
 
 protected:
   std::recursive_mutex reentrant_mutex_;

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -107,12 +107,11 @@ public:
   bool
   is_ready(rcl_wait_set_t * wait_set) override;
 
-  /// Set EventsExecutor's callback
   RCLCPP_PUBLIC
   void
-  set_events_executor_callback(
-    rmw_listener_callback_t executor_callback,
-    const void * executor_callback_data) const override;
+  set_listener_callback(
+    rmw_listener_callback_t callback,
+    const void * user_data) const override;
 
 protected:
   rcl_event_t event_handle_;

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -111,8 +111,8 @@ public:
   RCLCPP_PUBLIC
   void
   set_events_executor_callback(
-    rclcpp::executors::EventsExecutor * executor,
-    rmw_listener_callback_t executor_callback) const override;
+    rmw_listener_callback_t executor_callback,
+    const void * executor_callback_data) const override;
 
 protected:
   rcl_event_t event_handle_;

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -129,8 +129,8 @@ public:
   RCLCPP_PUBLIC
   void
   set_events_executor_callback(
-    rclcpp::executors::EventsExecutor * executor,
-    rmw_listener_callback_t executor_callback) const;
+    rmw_listener_callback_t executor_callback,
+    const void * executor_callback_data) const;
 
 protected:
   RCLCPP_DISABLE_COPY(ServiceBase)

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -128,9 +128,9 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_events_executor_callback(
-    rmw_listener_callback_t executor_callback,
-    const void * executor_callback_data) const;
+  set_listener_callback(
+    rmw_listener_callback_t callback,
+    const void * user_data) const;
 
 protected:
   RCLCPP_DISABLE_COPY(ServiceBase)

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -271,9 +271,9 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_events_executor_callback(
-    rmw_listener_callback_t executor_callback,
-    const void * executor_callback_data) const;
+  set_listener_callback(
+    rmw_listener_callback_t callback,
+    const void * user_data) const;
 
 protected:
   template<typename EventCallbackT>

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -272,8 +272,8 @@ public:
   RCLCPP_PUBLIC
   void
   set_events_executor_callback(
-    rclcpp::executors::EventsExecutor * executor,
-    rmw_listener_callback_t executor_callback) const;
+    rmw_listener_callback_t executor_callback,
+    const void * executor_callback_data) const;
 
 protected:
   template<typename EventCallbackT>

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -211,9 +211,9 @@ public:
   RCLCPP_PUBLIC
   virtual
   void
-  set_events_executor_callback(
-    rmw_listener_callback_t executor_callback,
-    const void * executor_callback_data) const;
+  set_listener_callback(
+    rmw_listener_callback_t callback,
+    const void * user_data) const;
 
 private:
   std::atomic<bool> in_use_by_wait_set_{false};

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -212,8 +212,8 @@ public:
   virtual
   void
   set_events_executor_callback(
-    rclcpp::executors::EventsExecutor * executor,
-    rmw_listener_callback_t executor_callback) const;
+    rmw_listener_callback_t executor_callback,
+    const void * executor_callback_data) const;
 
 private:
   std::atomic<bool> in_use_by_wait_set_{false};

--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -201,14 +201,13 @@ ClientBase::exchange_in_use_by_wait_set_state(bool in_use_state)
 
 void
 ClientBase::set_events_executor_callback(
-  rclcpp::executors::EventsExecutor * executor,
-  rmw_listener_callback_t executor_callback) const
+  rmw_listener_callback_t executor_callback,
+  const void * executor_callback_data) const
 {
   rcl_ret_t ret = rcl_client_set_listener_callback(
     client_handle_.get(),
     executor_callback,
-    executor,
-    this);
+    executor_callback_data);
 
   if (RCL_RET_OK != ret) {
     throw std::runtime_error("Couldn't set the EventsExecutor's callback to client");

--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -200,16 +200,16 @@ ClientBase::exchange_in_use_by_wait_set_state(bool in_use_state)
 }
 
 void
-ClientBase::set_events_executor_callback(
-  rmw_listener_callback_t executor_callback,
-  const void * executor_callback_data) const
+ClientBase::set_listener_callback(
+  rmw_listener_callback_t callback,
+  const void * user_data) const
 {
   rcl_ret_t ret = rcl_client_set_listener_callback(
     client_handle_.get(),
-    executor_callback,
-    executor_callback_data);
+    callback,
+    user_data);
 
   if (RCL_RET_OK != ret) {
-    throw std::runtime_error("Couldn't set the EventsExecutor's callback to client");
+    throw std::runtime_error("Couldn't set listener callback to client");
   }
 }

--- a/rclcpp/src/rclcpp/executors/events_executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/events_executor_entities_collector.cpp
@@ -238,7 +238,7 @@ EventsExecutorEntitiesCollector::set_callback_group_entities_callbacks(
       if (subscription) {
         weak_subscriptions_map_.emplace(subscription.get(), subscription);
 
-        subscription->set_events_executor_callback(
+        subscription->set_listener_callback(
           &EventsExecutor::push_event,
           get_callback_data(subscription.get(), SUBSCRIPTION_EVENT));
       }
@@ -249,7 +249,7 @@ EventsExecutorEntitiesCollector::set_callback_group_entities_callbacks(
       if (service) {
         weak_services_map_.emplace(service.get(), service);
 
-        service->set_events_executor_callback(
+        service->set_listener_callback(
           &EventsExecutor::push_event,
           get_callback_data(service.get(), SERVICE_EVENT));
       }
@@ -260,7 +260,7 @@ EventsExecutorEntitiesCollector::set_callback_group_entities_callbacks(
       if (client) {
         weak_clients_map_.emplace(client.get(), client);
 
-        client->set_events_executor_callback(
+        client->set_listener_callback(
           &EventsExecutor::push_event,
           get_callback_data(client.get(), CLIENT_EVENT));
       }
@@ -271,7 +271,7 @@ EventsExecutorEntitiesCollector::set_callback_group_entities_callbacks(
       if (waitable) {
         weak_waitables_map_.emplace(waitable.get(), waitable);
 
-        waitable->set_events_executor_callback(
+        waitable->set_listener_callback(
           &EventsExecutor::push_event,
           get_callback_data(waitable.get(), WAITABLE_EVENT));
       }
@@ -296,7 +296,7 @@ EventsExecutorEntitiesCollector::unset_callback_group_entities_callbacks(
   group->find_subscription_ptrs_if(
     [this](const rclcpp::SubscriptionBase::SharedPtr & subscription) {
       if (subscription) {
-        subscription->set_events_executor_callback(nullptr, nullptr);
+        subscription->set_listener_callback(nullptr, nullptr);
         weak_subscriptions_map_.erase(subscription.get());
         remove_callback_data(subscription.get(), SUBSCRIPTION_EVENT);
       }
@@ -305,7 +305,7 @@ EventsExecutorEntitiesCollector::unset_callback_group_entities_callbacks(
   group->find_service_ptrs_if(
     [this](const rclcpp::ServiceBase::SharedPtr & service) {
       if (service) {
-        service->set_events_executor_callback(nullptr, nullptr);
+        service->set_listener_callback(nullptr, nullptr);
         weak_services_map_.erase(service.get());
         remove_callback_data(service.get(), SERVICE_EVENT);
       }
@@ -314,7 +314,7 @@ EventsExecutorEntitiesCollector::unset_callback_group_entities_callbacks(
   group->find_client_ptrs_if(
     [this](const rclcpp::ClientBase::SharedPtr & client) {
       if (client) {
-        client->set_events_executor_callback(nullptr, nullptr);
+        client->set_listener_callback(nullptr, nullptr);
         weak_clients_map_.erase(client.get());
         remove_callback_data(client.get(), CLIENT_EVENT);
       }
@@ -323,7 +323,7 @@ EventsExecutorEntitiesCollector::unset_callback_group_entities_callbacks(
   group->find_waitable_ptrs_if(
     [this](const rclcpp::Waitable::SharedPtr & waitable) {
       if (waitable) {
-        waitable->set_events_executor_callback(nullptr, nullptr);
+        waitable->set_listener_callback(nullptr, nullptr);
         weak_waitables_map_.erase(waitable.get());
         remove_callback_data(waitable.get(), WAITABLE_EVENT);
       }
@@ -596,7 +596,7 @@ EventsExecutorEntitiesCollector::add_waitable(rclcpp::Waitable::SharedPtr waitab
 {
   weak_waitables_map_.emplace(waitable.get(), waitable);
 
-  waitable->set_events_executor_callback(
+  waitable->set_listener_callback(
     &EventsExecutor::push_event,
     get_callback_data(waitable.get(), WAITABLE_EVENT));
 }

--- a/rclcpp/src/rclcpp/executors/events_executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/events_executor_entities_collector.cpp
@@ -607,7 +607,8 @@ EventsExecutorEntitiesCollector::get_callback_data(
 {
   // Create an entity callback data object and check if
   // we already have stored one like it
-  EventsExecutorCallbackData data(associated_executor_, entity_id, event_type);
+  ExecutorEvent event = {entity_id, event_type};
+  EventsExecutorCallbackData data(associated_executor_, event);
 
   auto it = callback_data_map_.find(data);
 
@@ -633,7 +634,8 @@ EventsExecutorEntitiesCollector::remove_callback_data(
 {
   // Create an entity callback data object and check if
   // we already have stored one like it
-  EventsExecutorCallbackData data(associated_executor_, entity_id, event_type);
+  ExecutorEvent event = {entity_id, event_type};
+  EventsExecutorCallbackData data(associated_executor_, event);
 
   auto it = callback_data_map_.find(data);
 

--- a/rclcpp/src/rclcpp/qos_event.cpp
+++ b/rclcpp/src/rclcpp/qos_event.cpp
@@ -70,14 +70,13 @@ QOSEventHandlerBase::is_ready(rcl_wait_set_t * wait_set)
 
 void
 QOSEventHandlerBase::set_events_executor_callback(
-  rclcpp::executors::EventsExecutor * executor,
-  rmw_listener_callback_t executor_callback) const
+  rmw_listener_callback_t executor_callback,
+  const void * executor_callback_data) const
 {
   rcl_ret_t ret = rcl_event_set_listener_callback(
     &event_handle_,
     executor_callback,
-    executor,
-    this,
+    executor_callback_data,
     false /* Discard previous events */);
 
   if (RCL_RET_OK != ret) {

--- a/rclcpp/src/rclcpp/qos_event.cpp
+++ b/rclcpp/src/rclcpp/qos_event.cpp
@@ -69,18 +69,18 @@ QOSEventHandlerBase::is_ready(rcl_wait_set_t * wait_set)
 }
 
 void
-QOSEventHandlerBase::set_events_executor_callback(
-  rmw_listener_callback_t executor_callback,
-  const void * executor_callback_data) const
+QOSEventHandlerBase::set_listener_callback(
+  rmw_listener_callback_t callback,
+  const void * user_data) const
 {
   rcl_ret_t ret = rcl_event_set_listener_callback(
     &event_handle_,
-    executor_callback,
-    executor_callback_data,
+    callback,
+    user_data,
     false /* Discard previous events */);
 
   if (RCL_RET_OK != ret) {
-    throw std::runtime_error("Couldn't set EventsExecutor's callback in QOSEventHandlerBase");
+    throw std::runtime_error("Couldn't set listener callback to QOSEventHandlerBase");
   }
 }
 

--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -86,16 +86,16 @@ ServiceBase::exchange_in_use_by_wait_set_state(bool in_use_state)
 }
 
 void
-ServiceBase::set_events_executor_callback(
-  rmw_listener_callback_t executor_callback,
-  const void * executor_callback_data) const
+ServiceBase::set_listener_callback(
+  rmw_listener_callback_t callback,
+  const void * user_data) const
 {
   rcl_ret_t ret = rcl_service_set_listener_callback(
     service_handle_.get(),
-    executor_callback,
-    executor_callback_data);
+    callback,
+    user_data);
 
   if (RCL_RET_OK != ret) {
-    throw std::runtime_error("Couldn't set the EventsExecutor's callback to service");
+    throw std::runtime_error("Couldn't set listener callback to service");
   }
 }

--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -87,14 +87,13 @@ ServiceBase::exchange_in_use_by_wait_set_state(bool in_use_state)
 
 void
 ServiceBase::set_events_executor_callback(
-  rclcpp::executors::EventsExecutor * executor,
-  rmw_listener_callback_t executor_callback) const
+  rmw_listener_callback_t executor_callback,
+  const void * executor_callback_data) const
 {
   rcl_ret_t ret = rcl_service_set_listener_callback(
     service_handle_.get(),
     executor_callback,
-    executor,
-    this);
+    executor_callback_data);
 
   if (RCL_RET_OK != ret) {
     throw std::runtime_error("Couldn't set the EventsExecutor's callback to service");

--- a/rclcpp/src/rclcpp/subscription_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_base.cpp
@@ -290,16 +290,16 @@ SubscriptionBase::exchange_in_use_by_wait_set_state(
 }
 
 void
-SubscriptionBase::set_events_executor_callback(
-  rmw_listener_callback_t executor_callback,
-  const void * executor_callback_data) const
+SubscriptionBase::set_listener_callback(
+  rmw_listener_callback_t callback,
+  const void * user_data) const
 {
   rcl_ret_t ret = rcl_subscription_set_listener_callback(
     subscription_handle_.get(),
-    executor_callback,
-    executor_callback_data);
+    callback,
+    user_data);
 
   if (RCL_RET_OK != ret) {
-    throw std::runtime_error("Couldn't set the EventsExecutor's callback to subscription");
+    throw std::runtime_error("Couldn't set listener callback to subscription");
   }
 }

--- a/rclcpp/src/rclcpp/subscription_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_base.cpp
@@ -291,14 +291,13 @@ SubscriptionBase::exchange_in_use_by_wait_set_state(
 
 void
 SubscriptionBase::set_events_executor_callback(
-  rclcpp::executors::EventsExecutor * executor,
-  rmw_listener_callback_t executor_callback) const
+  rmw_listener_callback_t executor_callback,
+  const void * executor_callback_data) const
 {
   rcl_ret_t ret = rcl_subscription_set_listener_callback(
     subscription_handle_.get(),
     executor_callback,
-    executor,
-    this);
+    executor_callback_data);
 
   if (RCL_RET_OK != ret) {
     throw std::runtime_error("Couldn't set the EventsExecutor's callback to subscription");

--- a/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
@@ -38,17 +38,17 @@ SubscriptionIntraProcessBase::get_actual_qos() const
 }
 
 void
-SubscriptionIntraProcessBase::set_events_executor_callback(
-  rmw_listener_callback_t executor_callback,
-  const void * executor_callback_data) const
+SubscriptionIntraProcessBase::set_listener_callback(
+  rmw_listener_callback_t callback,
+  const void * user_data) const
 {
   rcl_ret_t ret = rcl_guard_condition_set_listener_callback(
     &gc_,
-    executor_callback,
-    executor_callback_data,
+    callback,
+    user_data,
     true /*Use previous events*/);
 
   if (RCL_RET_OK != ret) {
-    throw std::runtime_error("Couldn't set guard condition callback");
+    throw std::runtime_error("Couldn't set guard condition listener callback");
   }
 }

--- a/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
@@ -39,14 +39,13 @@ SubscriptionIntraProcessBase::get_actual_qos() const
 
 void
 SubscriptionIntraProcessBase::set_events_executor_callback(
-  rclcpp::executors::EventsExecutor * executor,
-  rmw_listener_callback_t executor_callback) const
+  rmw_listener_callback_t executor_callback,
+  const void * executor_callback_data) const
 {
   rcl_ret_t ret = rcl_guard_condition_set_listener_callback(
     &gc_,
     executor_callback,
-    executor,
-    this,
+    executor_callback_data,
     true /*Use previous events*/);
 
   if (RCL_RET_OK != ret) {

--- a/rclcpp/src/rclcpp/waitable.cpp
+++ b/rclcpp/src/rclcpp/waitable.cpp
@@ -62,11 +62,11 @@ Waitable::exchange_in_use_by_wait_set_state(bool in_use_state)
 
 void
 Waitable::set_events_executor_callback(
-  rclcpp::executors::EventsExecutor * executor,
-  rmw_listener_callback_t executor_callback) const
+  rmw_listener_callback_t executor_callback,
+  const void * executor_callback_data) const
 {
-  (void)executor;
   (void)executor_callback;
+  (void)executor_callback_data;
 
   throw std::runtime_error(
           "Custom waitables should override set_events_executor_callback() to use events executor");

--- a/rclcpp/src/rclcpp/waitable.cpp
+++ b/rclcpp/src/rclcpp/waitable.cpp
@@ -61,13 +61,13 @@ Waitable::exchange_in_use_by_wait_set_state(bool in_use_state)
 }
 
 void
-Waitable::set_events_executor_callback(
-  rmw_listener_callback_t executor_callback,
-  const void * executor_callback_data) const
+Waitable::set_listener_callback(
+  rmw_listener_callback_t callback,
+  const void * user_data) const
 {
-  (void)executor_callback;
-  (void)executor_callback_data;
+  (void)callback;
+  (void)user_data;
 
   throw std::runtime_error(
-          "Custom waitables should override set_events_executor_callback() to use events executor");
+    "Custom waitables should override set_listener_callback() to use events executor");
 }

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -574,7 +574,7 @@ if(TARGET test_events_queue)
   ament_target_dependencies(test_events_queue
     "rcl"
     "test_msgs")
-  target_link_libraries(test_events_queue ${PROJECT_NAME} mimick)
+  target_link_libraries(test_events_queue ${PROJECT_NAME})
 endif()
 
 ament_add_gtest(test_events_executor_entities_collector executors/test_events_executor_entities_collector.cpp

--- a/rclcpp/test/rclcpp/executors/test_events_queue.cpp
+++ b/rclcpp/test/rclcpp/executors/test_events_queue.cpp
@@ -25,7 +25,7 @@ TEST(TestEventsQueue, SimpleQueueTest)
 {
   // Create a SimpleEventsQueue and a local queue
   auto simple_queue = std::make_unique<rclcpp::experimental::buffers::SimpleEventsQueue>();
-  std::queue<rmw_listener_event_t> local_events_queue;
+  std::queue<rclcpp::executors::ExecutorEvent> local_events_queue;
 
   // Make sure the queue is empty after init
   simple_queue->init();
@@ -33,7 +33,7 @@ TEST(TestEventsQueue, SimpleQueueTest)
 
   // Push 11 messages
   for (int i = 0; i < 11; i++) {
-    rmw_listener_event_t stub_event;
+    rclcpp::executors::ExecutorEvent stub_event;
     simple_queue->push(stub_event);
   }
 
@@ -52,13 +52,14 @@ TEST(TestEventsQueue, SimpleQueueTest)
   EXPECT_TRUE(simple_queue->empty());
 
   // Lets push an event into the queue and get it back
-  rmw_listener_event_t push_event = {simple_queue.get(), SUBSCRIPTION_EVENT};
+  rclcpp::executors::ExecutorEvent push_event = {simple_queue.get(),
+    rclcpp::executors::ExecutorEventType::SUBSCRIPTION_EVENT};
 
   simple_queue->push(push_event);
 
-  rmw_listener_event_t front_event = simple_queue->front();
+  rclcpp::executors::ExecutorEvent front_event = simple_queue->front();
 
   // The events should be equal
-  EXPECT_EQ(push_event.entity, front_event.entity);
+  EXPECT_EQ(push_event.entity_id, front_event.entity_id);
   EXPECT_EQ(push_event.type, front_event.type);
 }

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -469,14 +469,13 @@ public:
 
   void
   set_events_executor_callback(
-    rclcpp::executors::EventsExecutor * executor,
-    rmw_listener_callback_t executor_callback) const override
+    rmw_listener_callback_t executor_callback,
+    const void * executor_callback_data) const override
   {
     rcl_ret_t ret = rcl_guard_condition_set_listener_callback(
       &gc_,
       executor_callback,
-      executor,
-      this,
+      executor_callback_data,
       true /*Use previous events*/);
 
     if (RCL_RET_OK != ret) {

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -468,14 +468,14 @@ public:
   }
 
   void
-  set_events_executor_callback(
-    rmw_listener_callback_t executor_callback,
-    const void * executor_callback_data) const override
+  set_listener_callback(
+    rmw_listener_callback_t callback,
+    const void * user_data) const override
   {
     rcl_ret_t ret = rcl_guard_condition_set_listener_callback(
       &gc_,
-      executor_callback,
-      executor_callback_data,
+      callback,
+      user_data,
       true /*Use previous events*/);
 
     if (RCL_RET_OK != ret) {


### PR DESCRIPTION
Group callback data types under a single struct:
```
struct 
{
  entity_id;      
  executor_ptr;    
  event_type;
}
```
A `void *` of this struct is passed down from rclcpp to the rmw, and is used as argument for the listeners callback.

The executor cast it back and uses it to push the correspoding event to the queue.