### PR TITLE
Mauro/add events executor

### DIFF
--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -28,18 +28,19 @@
 #include "rcl/error_handling.h"
 #include "rcl/wait.h"
 
+#include "rclcpp/detail/cpp_callback_trampoline.hpp"
 #include "rclcpp/exceptions.hpp"
+#include "rclcpp/expand_topic_or_service_name.hpp"
 #include "rclcpp/function_traits.hpp"
+#include "rclcpp/logging.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/node_interfaces/node_graph_interface.hpp"
 #include "rclcpp/type_support_decl.hpp"
 #include "rclcpp/utilities.hpp"
-#include "rclcpp/expand_topic_or_service_name.hpp"
 #include "rclcpp/visibility_control.hpp"
 
-#include "rcutils/logging_macros.h"
-
 #include "rmw/error_handling.h"
+#include "rmw/impl/cpp/demangle.hpp"
 #include "rmw/rmw.h"
 
 namespace rclcpp
@@ -150,11 +151,68 @@ public:
   bool
   exchange_in_use_by_wait_set_state(bool in_use_state);
 
-  RCLCPP_PUBLIC
+  /// Set a callback to be called when each new response is received.
+  /**
+   * The callback receives a size_t which is the number of responses received
+   * since the last time this callback was called.
+   * Normally this is 1, but can be > 1 if responses were received before any
+   * callback was set.
+   *
+   * Since this callback is called from the middleware, you should aim to make
+   * it fast and not blocking.
+   * If you need to do a lot of work or wait for some other event, you should
+   * spin it off to another thread, otherwise you risk blocking the middleware.
+   *
+   * Calling it again will clear any previously set callback.
+   *
+   * This function is thread-safe.
+   *
+   * If you want more information available in the callback, like the client
+   * or other information, you may use a lambda with captures or std::bind.
+   *
+   * \sa rmw_client_set_on_new_response_callback
+   * \sa rcl_client_set_on_new_response_callback
+   *
+   * \param[in] callback functor to be called when a new response is received
+   */
   void
-  set_listener_callback(
-    rmw_listener_callback_t callback,
-    const void * user_data) const;
+  set_on_new_response_callback(std::function<void(size_t)> callback)
+  {
+    auto new_callback =
+      [callback, this](size_t number_of_responses) {
+        try {
+          callback(number_of_responses);
+        } catch (const std::exception & exception) {
+          RCLCPP_ERROR_STREAM(
+            node_logger_,
+            "rclcpp::ClientBase@" << this <<
+              " caught " << rmw::impl::cpp::demangle(exception) <<
+              " exception in user-provided callback for the 'on new response' callback: " <<
+              exception.what());
+        } catch (...) {
+          RCLCPP_ERROR_STREAM(
+            node_logger_,
+            "rclcpp::ClientBase@" << this <<
+              " caught unhandled exception in user-provided callback " <<
+              "for the 'on new response' callback");
+        }
+      };
+
+    // Set it temporarily to the new callback, while we replace the old one.
+    // This two-step setting, prevents a gap where the old std::function has
+    // been replaced but the middleware hasn't been told about the new one yet.
+    set_on_new_response_callback(
+      rclcpp::detail::cpp_callback_trampoline<const void *, size_t>,
+      static_cast<const void *>(&new_callback));
+
+    // Store the std::function to keep it in scope, also overwrites the existing one.
+    on_new_response_callback_ = new_callback;
+
+    // Set it again, now using the permanent storage.
+    set_on_new_response_callback(
+      rclcpp::detail::cpp_callback_trampoline<const void *, size_t>,
+      static_cast<const void *>(&on_new_response_callback_));
+  }
 
 protected:
   RCLCPP_DISABLE_COPY(ClientBase)
@@ -171,13 +229,20 @@ protected:
   const rcl_node_t *
   get_rcl_node_handle() const;
 
+  RCLCPP_PUBLIC
+  void
+  set_on_new_response_callback(rcl_event_callback_t callback, const void * user_data);
+
   rclcpp::node_interfaces::NodeGraphInterface::WeakPtr node_graph_;
   std::shared_ptr<rcl_node_t> node_handle_;
   std::shared_ptr<rclcpp::Context> context_;
+  rclcpp::Logger node_logger_;
 
   std::shared_ptr<rcl_client_t> client_handle_;
 
   std::atomic<bool> in_use_by_wait_set_{false};
+
+  std::function<void(size_t)> on_new_response_callback_;
 };
 
 template<typename ServiceT>
@@ -303,8 +368,8 @@ public:
     int64_t sequence_number = request_header->sequence_number;
     // TODO(esteve) this should throw instead since it is not expected to happen in the first place
     if (this->pending_requests_.count(sequence_number) == 0) {
-      RCUTILS_LOG_ERROR_NAMED(
-        "rclcpp",
+      RCLCPP_ERROR(
+        node_logger_,
         "Received invalid sequence number. Ignoring...");
       return;
     }

--- a/rclcpp/include/rclcpp/detail/cpp_callback_trampoline.hpp
+++ b/rclcpp/include/rclcpp/detail/cpp_callback_trampoline.hpp
@@ -1,0 +1,67 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__DETAIL__CPP_CALLBACK_TRAMPOLINE_HPP_
+#define RCLCPP__DETAIL__CPP_CALLBACK_TRAMPOLINE_HPP_
+
+#include <functional>
+
+namespace rclcpp
+{
+
+namespace detail
+{
+
+/// Trampoline pattern for wrapping std::function into C-style callbacks.
+/**
+ * A common pattern in C is for a function to take a function pointer and a
+ * void pointer for "user data" which is passed to the function pointer when it
+ * is called from within C.
+ *
+ * It works by using the user data pointer to store a pointer to a
+ * std::function instance.
+ * So when called from C, this function will cast the user data to the right
+ * std::function type and call it.
+ *
+ * This should allow you to use free functions, lambdas with and without
+ * captures, and various kinds of std::bind instances.
+ *
+ * The interior of this function is likely to be executed within a C runtime,
+ * so no exceptins should be thrown at this point, and doing so results in
+ * undefined behavior.
+ *
+ * \tparam UserDataT Deduced type based on what is passed for user data,
+ *   usually this type is either `void *` or `const void *`.
+ * \tparam Args the arguments being passed to the callback
+ * \tparam ReturnT the return type of this function and the callback, default void
+ * \param user_data the function pointer, possibly type erased
+ * \returns whatever the callback returns, if anything
+ */
+template<
+  typename UserDataT,
+  typename ... Args,
+  typename ReturnT = void
+>
+ReturnT
+cpp_callback_trampoline(UserDataT user_data, Args ... args) noexcept
+{
+  auto & actual_callback = *reinterpret_cast<const std::function<ReturnT(Args...)> *>(user_data);
+  return actual_callback(args ...);
+}
+
+}  // namespace detail
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__DETAIL__CPP_CALLBACK_TRAMPOLINE_HPP_

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -524,7 +524,7 @@ protected:
   std::atomic_bool spinning;
 
   /// Guard condition for signaling the rmw layer to wake up for special events.
-  rcl_guard_condition_t interrupt_guard_condition_ = rcl_get_zero_initialized_guard_condition();
+  rclcpp::GuardCondition interrupt_guard_condition_;
 
   std::shared_ptr<rclcpp::GuardCondition> shutdown_guard_condition_;
 
@@ -548,7 +548,7 @@ protected:
   spin_once_impl(std::chrono::nanoseconds timeout);
 
   typedef std::map<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr,
-      const rcl_guard_condition_t *,
+      const rclcpp::GuardCondition *,
       std::owner_less<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr>>
     WeakNodesToGuardConditionsMap;
 

--- a/rclcpp/include/rclcpp/executors/events_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor.hpp
@@ -29,8 +29,6 @@
 #include "rclcpp/experimental/buffers/simple_events_queue.hpp"
 #include "rclcpp/node.hpp"
 
-#include "rmw/listener_callback_type.h"
-
 namespace rclcpp
 {
 namespace executors

--- a/rclcpp/include/rclcpp/executors/events_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor.hpp
@@ -209,31 +209,6 @@ protected:
 private:
   RCLCPP_DISABLE_COPY(EventsExecutor)
 
-  // Executor callback: Push new events into the queue and trigger cv.
-  // This function is called by the DDS entities when an event happened,
-  // like a subscription receiving a message.
-  static void
-  push_event(const void * event_data, size_t num_events)
-  {
-    if (!event_data) {
-      throw std::runtime_error("Executor event data not valid.");
-    }
-
-    auto data = static_cast<const executors::EventsExecutorCallbackData *>(event_data);
-
-    executors::EventsExecutor * this_executor = data->executor;
-    ExecutorEvent event = data->event;
-    event.num_events = num_events;
-
-    // Event queue mutex scope
-    {
-      std::unique_lock<std::mutex> lock(this_executor->push_mutex_);
-      this_executor->events_queue_->push(event);
-    }
-    // Notify that the event queue has some events in it.
-    this_executor->events_queue_cv_.notify_one();
-  }
-
   // Execute a single event
   RCLCPP_PUBLIC
   void

--- a/rclcpp/include/rclcpp/executors/events_executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_entities_collector.hpp
@@ -215,7 +215,10 @@ private:
   unset_guard_condition_callback(const rclcpp::GuardCondition * guard_condition);
 
   std::function<void(size_t)>
-  create_entity_callback(void * entity_id, ExecutorEventType type);
+  create_entity_callback(void * exec_entity_id, ExecutorEventType type);
+
+  std::function<void(size_t, int)>
+  create_waitable_callback(void * waitable_id);
 
   /// Return true if the node belongs to the collector
   /**

--- a/rclcpp/include/rclcpp/executors/events_executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_entities_collector.hpp
@@ -214,11 +214,8 @@ private:
   void
   unset_guard_condition_callback(const rclcpp::GuardCondition * guard_condition);
 
-  void
-  remove_callback_data(void * entity_id, ExecutorEventType type);
-
-  const EventsExecutorCallbackData *
-  get_callback_data(void * entity_id, ExecutorEventType type);
+  std::function<void(size_t)>
+  create_entity_callback(void * entity_id, ExecutorEventType type);
 
   /// Return true if the node belongs to the collector
   /**
@@ -269,17 +266,6 @@ private:
   EventsExecutor * associated_executor_ = nullptr;
   /// Instance of the timers manager used by the associated executor
   TimersManager::SharedPtr timers_manager_;
-
-  /// Callback data objects mapped to the number of listeners sharing the same object.
-  /// When no more listeners use the object, it can be removed from the map.
-  /// For example, the entities collector holds every node's guard condition, which
-  /// share the same EventsExecutorCallbackData object ptr to use as their callback arg:
-  ///    cb_data_object = {executor_ptr, entities_collector_ptr, WAITABLE_EVENT};
-  ///    Node1->gc(&cb_data_object)
-  ///    Node2->gc(&cb_data_object)
-  /// So the maps has: (cb_data_object, 2)
-  /// When both nodes are removed (counter = 0), the cb_data_object can be destroyed.
-  std::unordered_map<EventsExecutorCallbackData, size_t, KeyHasher> callback_data_map_;
 };
 
 }  // namespace executors

--- a/rclcpp/include/rclcpp/executors/events_executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_entities_collector.hpp
@@ -209,10 +209,10 @@ private:
   unset_callback_group_entities_callbacks(rclcpp::CallbackGroup::SharedPtr group);
 
   void
-  set_guard_condition_callback(const rcl_guard_condition_t * guard_condition);
+  set_guard_condition_callback(const rclcpp::GuardCondition * guard_condition);
 
   void
-  unset_guard_condition_callback(const rcl_guard_condition_t * guard_condition);
+  unset_guard_condition_callback(const rclcpp::GuardCondition * guard_condition);
 
   void
   remove_callback_data(void * entity_id, ExecutorEventType type);
@@ -249,7 +249,7 @@ private:
   WeakCallbackGroupsToNodesMap weak_groups_to_nodes_associated_with_executor_;
 
   typedef std::map<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr,
-      const rcl_guard_condition_t *,
+      const rclcpp::GuardCondition *,
       std::owner_less<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr>>
     WeakNodesToGuardConditionsMap;
   WeakNodesToGuardConditionsMap weak_nodes_to_guard_conditions_;

--- a/rclcpp/include/rclcpp/executors/events_executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_entities_collector.hpp
@@ -209,10 +209,10 @@ private:
   unset_callback_group_entities_callbacks(rclcpp::CallbackGroup::SharedPtr group);
 
   void
-  set_guard_condition_callback(const rclcpp::GuardCondition * guard_condition);
+  set_guard_condition_callback(rclcpp::GuardCondition * guard_condition);
 
   void
-  unset_guard_condition_callback(const rclcpp::GuardCondition * guard_condition);
+  unset_guard_condition_callback(rclcpp::GuardCondition * guard_condition);
 
   std::function<void(size_t)>
   create_entity_callback(void * exec_entity_id, ExecutorEventType type);
@@ -249,7 +249,7 @@ private:
   WeakCallbackGroupsToNodesMap weak_groups_to_nodes_associated_with_executor_;
 
   typedef std::map<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr,
-      const rclcpp::GuardCondition *,
+      rclcpp::GuardCondition *,
       std::owner_less<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr>>
     WeakNodesToGuardConditionsMap;
   WeakNodesToGuardConditionsMap weak_nodes_to_guard_conditions_;

--- a/rclcpp/include/rclcpp/executors/events_executor_event_types.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_event_types.hpp
@@ -20,9 +20,6 @@ namespace rclcpp
 namespace executors
 {
 
-// forward declaration of EventsExecutor to avoid circular dependency
-class EventsExecutor;
-
 enum ExecutorEventType
 {
   SUBSCRIPTION_EVENT,
@@ -36,42 +33,6 @@ struct ExecutorEvent
   const void * entity_id;
   ExecutorEventType type;
   size_t num_events;
-};
-
-// The EventsExecutorCallbackData struct is what the listeners
-// will use as argument when calling their callbacks from the
-// RMW implementation. The listeners get a (void *) of this struct,
-// and the executor is in charge to cast it back and use the data.
-struct EventsExecutorCallbackData
-{
-  EventsExecutorCallbackData(
-    EventsExecutor * _executor,
-    ExecutorEvent _event)
-  {
-    executor = _executor;
-    event = _event;
-  }
-
-  // Equal operator
-  bool operator==(const EventsExecutorCallbackData & other) const
-  {
-    return event.entity_id == other.event.entity_id;
-  }
-
-  // Struct members
-  EventsExecutor * executor;
-  ExecutorEvent event;
-};
-
-// To be able to use std::unordered_map with an EventsExecutorCallbackData
-// as key, we need a hasher. We use the entity ID as hash, since it is
-// unique for each EventsExecutorCallbackData object.
-struct KeyHasher
-{
-  size_t operator()(const EventsExecutorCallbackData & key) const
-  {
-    return std::hash<const void *>()(key.event.entity_id);
-  }
 };
 
 }  // namespace executors

--- a/rclcpp/include/rclcpp/executors/events_executor_event_types.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_event_types.hpp
@@ -30,7 +30,8 @@ enum ExecutorEventType
 
 struct ExecutorEvent
 {
-  const void * entity_id;
+  const void * exec_entity_id;
+  int gen_entity_id;
   ExecutorEventType type;
   size_t num_events;
 };

--- a/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
@@ -60,13 +60,12 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_listener_callback(
-    rmw_listener_callback_t callback,
-    const void * user_data) override
+  set_listener_callback(std::function<void(size_t, int)> callback) override
   {
-    for (auto gc : notify_guard_conditions_) {
-      // gc->set_listener_callback();
-    }
+    (void)callback;
+    // for (auto gc : notify_guard_conditions_) {
+    //   gc->set_listener_callback();
+    // }
   }
 
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
@@ -53,7 +53,7 @@ public:
 
   RCLCPP_PUBLIC
   void
-  add_guard_condition(const rcl_guard_condition_t * guard_condition)
+  add_guard_condition(const rclcpp::GuardCondition * guard_condition)
   {
     notify_guard_conditions_.push_back(guard_condition);
   }
@@ -65,14 +65,7 @@ public:
     const void * user_data) const override
   {
     for (auto gc : notify_guard_conditions_) {
-      rcl_ret_t ret = rcl_guard_condition_set_listener_callback(
-        gc,
-        callback,
-        user_data);
-
-      if (RCL_RET_OK != ret) {
-        throw std::runtime_error("Couldn't set guard condition events callback");
-      }
+      // gc->set_listener_callback();
     }
   }
 
@@ -85,7 +78,7 @@ public:
   }
 
 private:
-  std::list<const rcl_guard_condition_t *> notify_guard_conditions_;
+  std::list<const rclcpp::GuardCondition *> notify_guard_conditions_;
 };
 
 }  // namespace executors

--- a/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
@@ -62,7 +62,7 @@ public:
   void
   set_listener_callback(
     rmw_listener_callback_t callback,
-    const void * user_data) const override
+    const void * user_data) override
   {
     for (auto gc : notify_guard_conditions_) {
       // gc->set_listener_callback();

--- a/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
@@ -65,7 +65,7 @@ public:
   init(
     rcl_wait_set_t * p_wait_set,
     rclcpp::memory_strategy::MemoryStrategy::SharedPtr memory_strategy,
-    rcl_guard_condition_t * executor_guard_condition);
+    rclcpp::GuardCondition * executor_guard_condition);
 
   /// Finalize StaticExecutorEntitiesCollector to clear resources
   RCLCPP_PUBLIC
@@ -326,7 +326,7 @@ private:
   WeakCallbackGroupsToNodesMap weak_groups_to_nodes_associated_with_executor_;
 
   typedef std::map<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr,
-      const rcl_guard_condition_t *,
+      const rclcpp::GuardCondition *,
       std::owner_less<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr>>
     WeakNodesToGuardConditionsMap;
   WeakNodesToGuardConditionsMap weak_nodes_to_guard_conditions_;

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
@@ -148,7 +148,12 @@ private:
   void
   trigger_guard_condition()
   {
-    gc_.trigger();
+    if (on_new_message_callback_) {
+      on_new_message_callback_(1);
+    } else {
+      gc_.trigger();
+      unread_count_++;
+    }
   }
 
   template<typename T>

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -50,23 +50,23 @@ public:
 
   RCLCPP_PUBLIC
   size_t
-  get_number_of_ready_guard_conditions() {return 1;}
+  get_number_of_ready_guard_conditions() override {return 1;}
 
   RCLCPP_PUBLIC
   bool
-  add_to_wait_set(rcl_wait_set_t * wait_set);
+  add_to_wait_set(rcl_wait_set_t * wait_set) override;
 
-  virtual bool
-  is_ready(rcl_wait_set_t * wait_set) = 0;
+  bool
+  is_ready(rcl_wait_set_t * wait_set) override = 0;
+
+  std::shared_ptr<void>
+  take_data() override = 0;
+
+  void
+  execute(std::shared_ptr<void> & data) override = 0;
 
   virtual
-  std::shared_ptr<void>
-  take_data() = 0;
-
-  virtual void
-  execute(std::shared_ptr<void> & data) = 0;
-
-  virtual bool
+  bool
   use_take_shared_method() const = 0;
 
   RCLCPP_PUBLIC
@@ -76,12 +76,6 @@ public:
   RCLCPP_PUBLIC
   rmw_qos_profile_t
   get_actual_qos() const;
-
-  RCLCPP_PUBLIC
-  void
-  set_listener_callback(
-    rmw_listener_callback_t callback,
-    const void * user_data) const override;
 
 protected:
   std::recursive_mutex reentrant_mutex_;

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -84,6 +84,8 @@ public:
 protected:
   std::recursive_mutex reentrant_mutex_;
   rclcpp::GuardCondition gc_;
+  std::function<void(size_t)> on_new_message_callback_{nullptr};
+  size_t unread_count_{0};
 
 private:
   virtual void

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -25,6 +25,7 @@
 
 #include "rcl/error_handling.h"
 
+#include "rclcpp/guard_condition.hpp"
 #include "rclcpp/type_support_decl.hpp"
 #include "rclcpp/waitable.hpp"
 
@@ -39,8 +40,10 @@ public:
   RCLCPP_SMART_PTR_ALIASES_ONLY(SubscriptionIntraProcessBase)
 
   RCLCPP_PUBLIC
-  SubscriptionIntraProcessBase(const std::string & topic_name, rmw_qos_profile_t qos_profile)
-  : topic_name_(topic_name), qos_profile_(qos_profile)
+  SubscriptionIntraProcessBase(
+    rclcpp::Context::SharedPtr context,
+    const std::string & topic_name, rmw_qos_profile_t qos_profile)
+  : gc_(context), topic_name_(topic_name), qos_profile_(qos_profile)
   {}
 
   virtual ~SubscriptionIntraProcessBase() = default;
@@ -82,7 +85,7 @@ public:
 
 protected:
   std::recursive_mutex reentrant_mutex_;
-  rcl_guard_condition_t gc_;
+  rclcpp::GuardCondition gc_;
 
 private:
   virtual void

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -79,9 +79,7 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_listener_callback(
-    rmw_listener_callback_t callback,
-    const void * user_data) override;
+  set_listener_callback(std::function<void(size_t, int)> callback) override;
 
 protected:
   std::recursive_mutex reentrant_mutex_;

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -77,6 +77,12 @@ public:
   rmw_qos_profile_t
   get_actual_qos() const;
 
+  RCLCPP_PUBLIC
+  void
+  set_listener_callback(
+    rmw_listener_callback_t callback,
+    const void * user_data) override;
+
 protected:
   std::recursive_mutex reentrant_mutex_;
   rclcpp::GuardCondition gc_;

--- a/rclcpp/include/rclcpp/graph_listener.hpp
+++ b/rclcpp/include/rclcpp/graph_listener.hpp
@@ -24,6 +24,7 @@
 #include "rcl/guard_condition.h"
 #include "rcl/wait.h"
 #include "rclcpp/context.hpp"
+#include "rclcpp/guard_condition.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/node_interfaces/node_graph_interface.hpp"
 #include "rclcpp/visibility_control.hpp"
@@ -187,7 +188,7 @@ private:
   mutable std::mutex node_graph_interfaces_mutex_;
   std::vector<rclcpp::node_interfaces::NodeGraphInterface *> node_graph_interfaces_;
 
-  rcl_guard_condition_t interrupt_guard_condition_ = rcl_get_zero_initialized_guard_condition();
+  rclcpp::GuardCondition interrupt_guard_condition_;
   rcl_wait_set_t wait_set_ = rcl_get_zero_initialized_wait_set();
 };
 

--- a/rclcpp/include/rclcpp/guard_condition.hpp
+++ b/rclcpp/include/rclcpp/guard_condition.hpp
@@ -47,7 +47,9 @@ public:
   RCLCPP_PUBLIC
   explicit GuardCondition(
     rclcpp::Context::SharedPtr context =
-    rclcpp::contexts::get_global_default_context());
+    rclcpp::contexts::get_global_default_context(),
+    rcl_guard_condition_options_t guard_condition_options =
+    rcl_guard_condition_get_default_options());
 
   RCLCPP_PUBLIC
   virtual
@@ -88,6 +90,15 @@ public:
   RCLCPP_PUBLIC
   bool
   exchange_in_use_by_wait_set_state(bool in_use_state);
+
+  /// Adds the guard condition to a waitset
+  /**
+   * This function is thread-safe.
+   * \param[in] wait_set pointer to a wait set where to add the guard condition
+   */
+  RCLCPP_PUBLIC
+  void
+  add_to_wait_set(rcl_wait_set_t * wait_set) const;
 
 protected:
   rclcpp::Context::SharedPtr context_;

--- a/rclcpp/include/rclcpp/guard_condition.hpp
+++ b/rclcpp/include/rclcpp/guard_condition.hpp
@@ -102,7 +102,7 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_on_trigger_callback(std::function<void(size_t, int)> callback);
+  set_on_trigger_callback(std::function<void(size_t)> callback);
 
 protected:
   rclcpp::Context::SharedPtr context_;

--- a/rclcpp/include/rclcpp/guard_condition.hpp
+++ b/rclcpp/include/rclcpp/guard_condition.hpp
@@ -100,10 +100,16 @@ public:
   void
   add_to_wait_set(rcl_wait_set_t * wait_set) const;
 
+  RCLCPP_PUBLIC
+  void
+  set_on_trigger_callback(std::function<void(size_t, int)> callback);
+
 protected:
   rclcpp::Context::SharedPtr context_;
   rcl_guard_condition_t rcl_guard_condition_;
   std::atomic<bool> in_use_by_wait_set_{false};
+  std::function<void(size_t)> on_trigger_callback_{nullptr};
+  size_t unread_count_{0};
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -64,9 +64,11 @@ public:
   virtual void clear_handles() = 0;
   virtual void remove_null_handles(rcl_wait_set_t * wait_set) = 0;
 
-  virtual void add_guard_condition(const rcl_guard_condition_t * guard_condition) = 0;
+  virtual void
+  add_guard_condition(const rclcpp::GuardCondition * guard_condition) = 0;
 
-  virtual void remove_guard_condition(const rcl_guard_condition_t * guard_condition) = 0;
+  virtual void
+  remove_guard_condition(const rclcpp::GuardCondition * guard_condition) = 0;
 
   virtual void
   get_next_subscription(

--- a/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
@@ -104,8 +104,12 @@ public:
   get_associated_with_executor_atomic() override;
 
   RCLCPP_PUBLIC
-  rcl_guard_condition_t *
+  const rcl_guard_condition_t *
   get_notify_guard_condition() override;
+
+  RCLCPP_PUBLIC
+  rclcpp::GuardCondition *
+  get_notify_rclcpp_guard_condition() override;
 
   RCLCPP_PUBLIC
   std::unique_lock<std::recursive_mutex>
@@ -121,6 +125,10 @@ public:
   std::string
   resolve_topic_or_service_name(
     const std::string & name, bool is_service, bool only_expand = false) const override;
+
+  RCLCPP_PUBLIC
+  void
+  trigger_notify_guard_condition() override;
 
 private:
   RCLCPP_DISABLE_COPY(NodeBase)
@@ -138,7 +146,7 @@ private:
 
   /// Guard condition for notifying the Executor of changes to this node.
   mutable std::recursive_mutex notify_guard_condition_mutex_;
-  rcl_guard_condition_t notify_guard_condition_ = rcl_get_zero_initialized_guard_condition();
+  rclcpp::GuardCondition notify_guard_condition_;
   bool notify_guard_condition_is_valid_;
 };
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
@@ -24,6 +24,7 @@
 
 #include "rclcpp/callback_group.hpp"
 #include "rclcpp/context.hpp"
+#include "rclcpp/guard_condition.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/visibility_control.hpp"
 
@@ -142,8 +143,19 @@ public:
    */
   RCLCPP_PUBLIC
   virtual
-  rcl_guard_condition_t *
+  const rcl_guard_condition_t *
   get_notify_guard_condition() = 0;
+
+  /// Return guard condition that should be notified when the internal node state changes.
+  /**
+   * For example, this should be notified when a publisher is added or removed.
+   *
+   * \return the GuardCondition if it is valid, else nullptr
+   */
+  RCLCPP_PUBLIC
+  virtual
+  rclcpp::GuardCondition *
+  get_notify_rclcpp_guard_condition() = 0;
 
   /// Acquire and return a scoped lock that protects the notify guard condition.
   /** This should be used when triggering the notify guard condition. */
@@ -170,6 +182,12 @@ public:
   std::string
   resolve_topic_or_service_name(
     const std::string & name, bool is_service, bool only_expand = false) const = 0;
+
+  /// Trigger the node's notify guard condition.
+  RCLCPP_PUBLIC
+  virtual
+  void
+  trigger_notify_guard_condition() = 0;
 };
 
 }  // namespace node_interfaces

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -171,9 +171,7 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_listener_callback(
-    rmw_listener_callback_t callback,
-    const void * user_data) override;
+  set_listener_callback(std::function<void(size_t, int)> callback) override;
 
 protected:
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -169,6 +169,12 @@ public:
       static_cast<const void *>(&on_new_event_callback_));
   }
 
+  RCLCPP_PUBLIC
+  void
+  set_listener_callback(
+    rmw_listener_callback_t callback,
+    const void * user_data) override;
+
 protected:
   RCLCPP_PUBLIC
   void

--- a/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
@@ -61,7 +61,7 @@ public:
     allocator_ = std::make_shared<VoidAlloc>();
   }
 
-  void add_guard_condition(const rcl_guard_condition_t * guard_condition) override
+  void add_guard_condition(const rclcpp::GuardCondition * guard_condition) override
   {
     for (const auto & existing_guard_condition : guard_conditions_) {
       if (existing_guard_condition == guard_condition) {
@@ -71,7 +71,7 @@ public:
     guard_conditions_.push_back(guard_condition);
   }
 
-  void remove_guard_condition(const rcl_guard_condition_t * guard_condition) override
+  void remove_guard_condition(const rclcpp::GuardCondition * guard_condition) override
   {
     for (auto it = guard_conditions_.begin(); it != guard_conditions_.end(); ++it) {
       if (*it == guard_condition) {
@@ -240,13 +240,7 @@ public:
     }
 
     for (auto guard_condition : guard_conditions_) {
-      if (rcl_wait_set_add_guard_condition(wait_set, guard_condition, NULL) != RCL_RET_OK) {
-        RCUTILS_LOG_ERROR_NAMED(
-          "rclcpp",
-          "Couldn't add guard_condition to wait set: %s",
-          rcl_get_error_string().str);
-        return false;
-      }
+      guard_condition->add_to_wait_set(wait_set);
     }
 
     for (auto waitable : waitable_handles_) {
@@ -504,7 +498,7 @@ private:
   using VectorRebind =
     std::vector<T, typename std::allocator_traits<Alloc>::template rebind_alloc<T>>;
 
-  VectorRebind<const rcl_guard_condition_t *> guard_conditions_;
+  VectorRebind<const rclcpp::GuardCondition *> guard_conditions_;
 
   VectorRebind<std::shared_ptr<const rcl_subscription_t>> subscription_handles_;
   VectorRebind<std::shared_ptr<const rcl_service_t>> service_handles_;

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -24,9 +24,11 @@
 
 #include "rcl/subscription.h"
 
+#include "rmw/impl/cpp/demangle.hpp"
 #include "rmw/rmw.h"
 
 #include "rclcpp/any_subscription_callback.hpp"
+#include "rclcpp/detail/cpp_callback_trampoline.hpp"
 #include "rclcpp/experimental/intra_process_manager.hpp"
 #include "rclcpp/experimental/subscription_intra_process_base.hpp"
 #include "rclcpp/macros.hpp"
@@ -263,11 +265,68 @@ public:
   bool
   exchange_in_use_by_wait_set_state(void * pointer_to_subscription_part, bool in_use_state);
 
-  RCLCPP_PUBLIC
+  /// Set a callback to be called when each new message is received.
+  /**
+   * The callback receives a size_t which is the number of messages received
+   * since the last time this callback was called.
+   * Normally this is 1, but can be > 1 if messages were received before any
+   * callback was set.
+   *
+   * Since this callback is called from the middleware, you should aim to make
+   * it fast and not blocking.
+   * If you need to do a lot of work or wait for some other event, you should
+   * spin it off to another thread, otherwise you risk blocking the middleware.
+   *
+   * Calling it again will clear any previously set callback.
+   *
+   * This function is thread-safe.
+   *
+   * If you want more information available in the callback, like the subscription
+   * or other information, you may use a lambda with captures or std::bind.
+   *
+   * \sa rmw_subscription_set_on_new_message_callback
+   * \sa rcl_subscription_set_on_new_message_callback
+   *
+   * \param[in] callback functor to be called when a new message is received
+   */
   void
-  set_listener_callback(
-    rmw_listener_callback_t callback,
-    const void * user_data) const;
+  set_on_new_message_callback(std::function<void(size_t)> callback)
+  {
+    auto new_callback =
+      [callback, this](size_t number_of_messages) {
+        try {
+          callback(number_of_messages);
+        } catch (const std::exception & exception) {
+          RCLCPP_ERROR_STREAM(
+            node_logger_,
+            "rclcpp::SubscriptionBase@" << this <<
+              " caught " << rmw::impl::cpp::demangle(exception) <<
+              " exception in user-provided callback for the 'on new message' callback: " <<
+              exception.what());
+        } catch (...) {
+          RCLCPP_ERROR_STREAM(
+            node_logger_,
+            "rclcpp::SubscriptionBase@" << this <<
+              " caught unhandled exception in user-provided callback " <<
+              "for the 'on new message' callback");
+        }
+      };
+
+    // Set it temporarily to the new callback, while we replace the old one.
+    // This two-step setting, prevents a gap where the old std::function has
+    // been replaced but the middleware hasn't been told about the new one yet.
+    set_on_new_message_callback(
+      rclcpp::detail::cpp_callback_trampoline<const void *, size_t>,
+      static_cast<const void *>(&new_callback));
+
+    // Store the std::function to keep it in scope, also overwrites the existing one.
+    on_new_message_callback_ = new_callback;
+
+    // Set it again, now using the permanent storage.
+    set_on_new_message_callback(
+      rclcpp::detail::cpp_callback_trampoline<const void *, size_t>,
+      static_cast<const void *>(&on_new_message_callback_));
+  }
 
 protected:
   template<typename EventCallbackT>
@@ -293,11 +352,16 @@ protected:
   bool
   matches_any_intra_process_publishers(const rmw_gid_t * sender_gid) const;
 
+  RCLCPP_PUBLIC
+  void
+  set_on_new_message_callback(rcl_event_callback_t callback, const void * user_data);
+
   rclcpp::node_interfaces::NodeBaseInterface * const node_base_;
 
   std::shared_ptr<rcl_node_t> node_handle_;
   std::shared_ptr<rcl_subscription_t> subscription_handle_;
   std::shared_ptr<rcl_subscription_t> intra_process_subscription_handle_;
+  rclcpp::Logger node_logger_;
 
   std::vector<std::shared_ptr<rclcpp::QOSEventHandlerBase>> event_handlers_;
 
@@ -315,6 +379,8 @@ private:
   std::atomic<bool> intra_process_subscription_waitable_in_use_by_wait_set_{false};
   std::unordered_map<rclcpp::QOSEventHandlerBase *,
     std::atomic<bool>> qos_events_in_use_by_wait_set_;
+
+  std::function<void(size_t)> on_new_message_callback_;
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -207,9 +207,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   void
-  set_listener_callback(
-    rmw_listener_callback_t callback,
-    const void * user_data);
+  set_listener_callback(std::function<void(size_t, int)> callback);
 
 private:
   std::atomic<bool> in_use_by_wait_set_{false};

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -16,6 +16,7 @@
 #define RCLCPP__WAITABLE_HPP_
 
 #include <atomic>
+#include <functional>
 #include <memory>
 
 #include "rclcpp/macros.hpp"

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -203,6 +203,13 @@ public:
   bool
   exchange_in_use_by_wait_set_state(bool in_use_state);
 
+  RCLCPP_PUBLIC
+  virtual
+  void
+  set_listener_callback(
+    rmw_listener_callback_t callback,
+    const void * user_data);
+
 private:
   std::atomic<bool> in_use_by_wait_set_{false};
 };  // class Waitable

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -203,13 +203,6 @@ public:
   bool
   exchange_in_use_by_wait_set_state(bool in_use_state);
 
-  RCLCPP_PUBLIC
-  virtual
-  void
-  set_listener_callback(
-    rmw_listener_callback_t callback,
-    const void * user_data) const;
-
 private:
   std::atomic<bool> in_use_by_wait_set_{false};
 };  // class Waitable

--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -38,7 +38,8 @@ ClientBase::ClientBase(
   rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph)
 : node_graph_(node_graph),
   node_handle_(node_base->get_shared_rcl_node_handle()),
-  context_(node_base->get_context())
+  context_(node_base->get_context()),
+  node_logger_(rclcpp::get_node_logger(node_handle_.get()))
 {
   std::weak_ptr<rcl_node_t> weak_node_handle(node_handle_);
   rcl_client_t * new_rcl_client = new rcl_client_t;
@@ -200,16 +201,15 @@ ClientBase::exchange_in_use_by_wait_set_state(bool in_use_state)
 }
 
 void
-ClientBase::set_listener_callback(
-  rmw_listener_callback_t callback,
-  const void * user_data) const
+ClientBase::set_on_new_response_callback(rcl_event_callback_t callback, const void * user_data)
 {
-  rcl_ret_t ret = rcl_client_set_listener_callback(
+  rcl_ret_t ret = rcl_client_set_on_new_response_callback(
     client_handle_.get(),
     callback,
     user_data);
 
   if (RCL_RET_OK != ret) {
-    throw std::runtime_error("Couldn't set listener callback to client");
+    using rclcpp::exceptions::throw_from_rcl_error;
+    throw_from_rcl_error(ret, "failed to set the on new response callback for client");
   }
 }

--- a/rclcpp/src/rclcpp/context.cpp
+++ b/rclcpp/src/rclcpp/context.cpp
@@ -31,8 +31,6 @@
 #include "rcutils/error_handling.h"
 #include "rcutils/macros.h"
 
-#include "rmw/impl/cpp/demangle.hpp"
-
 #include "./logging_mutex.hpp"
 
 using rclcpp::Context;

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -43,18 +43,12 @@ using rclcpp::FutureReturnCode;
 
 Executor::Executor(const rclcpp::ExecutorOptions & options)
 : spinning(false),
+  interrupt_guard_condition_(options.context),
   shutdown_guard_condition_(std::make_shared<rclcpp::GuardCondition>(options.context)),
   memory_strategy_(options.memory_strategy)
 {
   // Store the context for later use.
   context_ = options.context;
-
-  rcl_guard_condition_options_t guard_condition_options = rcl_guard_condition_get_default_options();
-  rcl_ret_t ret = rcl_guard_condition_init(
-    &interrupt_guard_condition_, context_->get_rcl_context().get(), guard_condition_options);
-  if (RCL_RET_OK != ret) {
-    throw_from_rcl_error(ret, "Failed to create interrupt guard condition in Executor constructor");
-  }
 
   context_->on_shutdown(
     [weak_gc = std::weak_ptr<rclcpp::GuardCondition>{shutdown_guard_condition_}]() {
@@ -66,13 +60,13 @@ Executor::Executor(const rclcpp::ExecutorOptions & options)
 
   // The number of guard conditions is always at least 2: 1 for the ctrl-c guard cond,
   // and one for the executor's guard cond (interrupt_guard_condition_)
-  memory_strategy_->add_guard_condition(&shutdown_guard_condition_->get_rcl_guard_condition());
+  memory_strategy_->add_guard_condition(shutdown_guard_condition_.get());
 
   // Put the executor's guard condition in
   memory_strategy_->add_guard_condition(&interrupt_guard_condition_);
   rcl_allocator_t allocator = memory_strategy_->get_allocator();
 
-  ret = rcl_wait_set_init(
+  rcl_ret_t ret = rcl_wait_set_init(
     &wait_set_,
     0, 2, 0, 0, 0, 0,
     context_->get_rcl_context().get(),
@@ -82,12 +76,6 @@ Executor::Executor(const rclcpp::ExecutorOptions & options)
       "rclcpp",
       "failed to create wait set: %s", rcl_get_error_string().str);
     rcl_reset_error();
-    if (rcl_guard_condition_fini(&interrupt_guard_condition_) != RCL_RET_OK) {
-      RCUTILS_LOG_ERROR_NAMED(
-        "rclcpp",
-        "failed to destroy guard condition: %s", rcl_get_error_string().str);
-      rcl_reset_error();
-    }
     throw_from_rcl_error(ret, "Failed to create wait set in Executor constructor");
   }
 }
@@ -129,15 +117,9 @@ Executor::~Executor()
       "failed to destroy wait set: %s", rcl_get_error_string().str);
     rcl_reset_error();
   }
-  // Finalize the interrupt guard condition.
-  if (rcl_guard_condition_fini(&interrupt_guard_condition_) != RCL_RET_OK) {
-    RCUTILS_LOG_ERROR_NAMED(
-      "rclcpp",
-      "failed to destroy guard condition: %s", rcl_get_error_string().str);
-    rcl_reset_error();
-  }
   // Remove and release the sigint guard condition
-  memory_strategy_->remove_guard_condition(&shutdown_guard_condition_->get_rcl_guard_condition());
+  memory_strategy_->remove_guard_condition(shutdown_guard_condition_.get());
+  memory_strategy_->remove_guard_condition(&interrupt_guard_condition_);
 }
 
 std::vector<rclcpp::CallbackGroup::WeakPtr>
@@ -227,16 +209,13 @@ Executor::add_callback_group_to_map(
   weak_groups_to_nodes_.insert(std::make_pair(weak_group_ptr, node_ptr));
   if (is_new_node) {
     rclcpp::node_interfaces::NodeBaseInterface::WeakPtr node_weak_ptr(node_ptr);
-    weak_nodes_to_guard_conditions_[node_weak_ptr] = node_ptr->get_notify_guard_condition();
+    weak_nodes_to_guard_conditions_[node_weak_ptr] = node_ptr->get_notify_rclcpp_guard_condition();
     if (notify) {
       // Interrupt waiting to handle new node
-      rcl_ret_t ret = rcl_trigger_guard_condition(&interrupt_guard_condition_);
-      if (ret != RCL_RET_OK) {
-        throw_from_rcl_error(ret, "Failed to trigger guard condition on callback group add");
-      }
+      interrupt_guard_condition_.trigger();
     }
     // Add the node's notify condition to the guard condition handles
-    memory_strategy_->add_guard_condition(node_ptr->get_notify_guard_condition());
+    memory_strategy_->add_guard_condition(node_ptr->get_notify_rclcpp_guard_condition());
   }
 }
 
@@ -306,12 +285,9 @@ Executor::remove_callback_group_from_map(
     rclcpp::node_interfaces::NodeBaseInterface::WeakPtr node_weak_ptr(node_ptr);
     weak_nodes_to_guard_conditions_.erase(node_weak_ptr);
     if (notify) {
-      rcl_ret_t ret = rcl_trigger_guard_condition(&interrupt_guard_condition_);
-      if (ret != RCL_RET_OK) {
-        throw_from_rcl_error(ret, "Failed to trigger guard condition on callback group remove");
-      }
+      interrupt_guard_condition_.trigger();
     }
-    memory_strategy_->remove_guard_condition(node_ptr->get_notify_guard_condition());
+    memory_strategy_->remove_guard_condition(node_ptr->get_notify_rclcpp_guard_condition());
   }
 }
 
@@ -482,10 +458,7 @@ void
 Executor::cancel()
 {
   spinning.store(false);
-  rcl_ret_t ret = rcl_trigger_guard_condition(&interrupt_guard_condition_);
-  if (ret != RCL_RET_OK) {
-    throw_from_rcl_error(ret, "Failed to trigger guard condition in cancel");
-  }
+  interrupt_guard_condition_.trigger();
 }
 
 void
@@ -523,10 +496,7 @@ Executor::execute_any_executable(AnyExecutable & any_exec)
   any_exec.callback_group->can_be_taken_from().store(true);
   // Wake the wait, because it may need to be recalculated or work that
   // was previously blocked is now available.
-  rcl_ret_t ret = rcl_trigger_guard_condition(&interrupt_guard_condition_);
-  if (ret != RCL_RET_OK) {
-    throw_from_rcl_error(ret, "Failed to trigger guard condition from execute_any_executable");
-  }
+  interrupt_guard_condition_.trigger();
 }
 
 static

--- a/rclcpp/src/rclcpp/executors/events_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/events_executor.cpp
@@ -253,7 +253,7 @@ EventsExecutor::execute_event(const ExecutorEvent & event)
   switch (event.type) {
     case SUBSCRIPTION_EVENT:
       {
-        auto subscription = entities_collector_->get_subscription(event.entity_id);
+        auto subscription = entities_collector_->get_subscription(event.exec_entity_id);
 
         if (subscription) {
           for (size_t i = 0; i < event.num_events; i++) {
@@ -265,7 +265,7 @@ EventsExecutor::execute_event(const ExecutorEvent & event)
 
     case SERVICE_EVENT:
       {
-        auto service = entities_collector_->get_service(event.entity_id);
+        auto service = entities_collector_->get_service(event.exec_entity_id);
 
         if (service) {
           for (size_t i = 0; i < event.num_events; i++) {
@@ -277,7 +277,7 @@ EventsExecutor::execute_event(const ExecutorEvent & event)
 
     case CLIENT_EVENT:
       {
-        auto client = entities_collector_->get_client(event.entity_id);
+        auto client = entities_collector_->get_client(event.exec_entity_id);
 
         if (client) {
           for (size_t i = 0; i < event.num_events; i++) {
@@ -289,7 +289,7 @@ EventsExecutor::execute_event(const ExecutorEvent & event)
 
     case WAITABLE_EVENT:
       {
-        auto waitable = entities_collector_->get_waitable(event.entity_id);
+        auto waitable = entities_collector_->get_waitable(event.exec_entity_id);
 
         if (waitable) {
           for (size_t i = 0; i < event.num_events; i++) {

--- a/rclcpp/src/rclcpp/executors/events_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/events_executor.cpp
@@ -47,7 +47,7 @@ EventsExecutor::EventsExecutor(
   // Setup the executor notifier to wake up the executor when some guard conditions are tiggered.
   // The added guard conditions are guaranteed to not go out of scope before the executor itself.
   executor_notifier_ = std::make_shared<EventsExecutorNotifyWaitable>();
-  executor_notifier_->add_guard_condition(&shutdown_guard_condition_->get_rcl_guard_condition());
+  executor_notifier_->add_guard_condition(shutdown_guard_condition_.get());
   executor_notifier_->add_guard_condition(&interrupt_guard_condition_);
 
   entities_collector_->add_waitable(executor_notifier_);

--- a/rclcpp/src/rclcpp/executors/events_executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/events_executor_entities_collector.cpp
@@ -67,7 +67,7 @@ EventsExecutorEntitiesCollector::~EventsExecutorEntitiesCollector()
   for (const auto & pair : weak_nodes_to_guard_conditions_) {
     auto node = pair.first.lock();
     if (node) {
-      auto node_gc = pair.second;
+      auto & node_gc = pair.second;
       unset_guard_condition_callback(node_gc);
     }
   }
@@ -267,8 +267,8 @@ EventsExecutorEntitiesCollector::set_callback_group_entities_callbacks(
       if (waitable) {
         weak_waitables_map_.emplace(waitable.get(), waitable);
 
-        // waitable->set_listener_callback(
-        //   create_entity_callback(waitable.get(), WAITABLE_EVENT));
+        waitable->set_listener_callback(
+          create_waitable_callback(waitable.get()));
       }
       return false;
     });
@@ -476,15 +476,16 @@ EventsExecutorEntitiesCollector::get_automatically_added_callback_groups_from_no
 
 void
 EventsExecutorEntitiesCollector::set_guard_condition_callback(
-  const rclcpp::GuardCondition * guard_condition)
+  rclcpp::GuardCondition * guard_condition)
 {
-  create_waitable_callback(this);
+  guard_condition->set_on_trigger_callback(create_waitable_callback(this));
 }
 
 void
 EventsExecutorEntitiesCollector::unset_guard_condition_callback(
-  const rclcpp::GuardCondition * guard_condition)
+  rclcpp::GuardCondition * guard_condition)
 {
+   guard_condition->set_on_trigger_callback(nullptr);
 }
 
 rclcpp::SubscriptionBase::SharedPtr

--- a/rclcpp/src/rclcpp/executors/events_executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/events_executor_entities_collector.cpp
@@ -141,10 +141,10 @@ EventsExecutorEntitiesCollector::add_callback_group(
   if (is_new_node) {
     // Set an event callback for the node's notify guard condition, so if new entities are added
     // or removed to this node we will receive an event.
-    set_guard_condition_callback(node_ptr->get_notify_guard_condition());
+    set_guard_condition_callback(node_ptr->get_notify_rclcpp_guard_condition());
 
     // Store node's notify guard condition
-    weak_nodes_to_guard_conditions_[node_ptr] = node_ptr->get_notify_guard_condition();
+    weak_nodes_to_guard_conditions_[node_ptr] = node_ptr->get_notify_rclcpp_guard_condition();
   }
 
   // Add callback group to weak_groups_to_node
@@ -375,7 +375,7 @@ EventsExecutorEntitiesCollector::remove_callback_group_from_map(
     // Node doesn't have more callback groups associated to the executor.
     // Unset the event callback for the node's notify guard condition, to stop
     // receiving events if entities are added or removed to this node.
-    unset_guard_condition_callback(node_ptr->get_notify_guard_condition());
+    unset_guard_condition_callback(node_ptr->get_notify_rclcpp_guard_condition());
 
     // Remove guard condition from list
     rclcpp::node_interfaces::NodeBaseInterface::WeakPtr weak_node_ptr(node_ptr);
@@ -485,7 +485,7 @@ EventsExecutorEntitiesCollector::get_automatically_added_callback_groups_from_no
 
 void
 EventsExecutorEntitiesCollector::set_guard_condition_callback(
-  const rcl_guard_condition_t * guard_condition)
+  const rclcpp::GuardCondition * guard_condition)
 {
   rcl_ret_t ret = rcl_guard_condition_set_listener_callback(
     guard_condition,
@@ -499,7 +499,7 @@ EventsExecutorEntitiesCollector::set_guard_condition_callback(
 
 void
 EventsExecutorEntitiesCollector::unset_guard_condition_callback(
-  const rcl_guard_condition_t * guard_condition)
+  const rclcpp::GuardCondition * guard_condition)
 {
   rcl_ret_t ret = rcl_guard_condition_set_listener_callback(
     guard_condition, nullptr, nullptr);

--- a/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
@@ -62,7 +62,7 @@ void
 StaticExecutorEntitiesCollector::init(
   rcl_wait_set_t * p_wait_set,
   rclcpp::memory_strategy::MemoryStrategy::SharedPtr memory_strategy,
-  rcl_guard_condition_t * executor_guard_condition)
+  GuardCondition * executor_guard_condition)
 {
   // Empty initialize executable list
   exec_list_ = rclcpp::experimental::ExecutableList();
@@ -263,10 +263,7 @@ StaticExecutorEntitiesCollector::add_to_wait_set(rcl_wait_set_t * wait_set)
   // Add waitable guard conditions (one for each registered node) into the wait set.
   for (const auto & pair : weak_nodes_to_guard_conditions_) {
     auto & gc = pair.second;
-    rcl_ret_t ret = rcl_wait_set_add_guard_condition(wait_set, gc, NULL);
-    if (ret != RCL_RET_OK) {
-      throw std::runtime_error("Executor waitable: couldn't add guard condition to wait set");
-    }
+    gc->add_to_wait_set(wait_set);
   }
   return true;
 }
@@ -323,7 +320,7 @@ StaticExecutorEntitiesCollector::add_callback_group(
     throw std::runtime_error("Callback group was already added to executor.");
   }
   if (is_new_node) {
-    weak_nodes_to_guard_conditions_[node_ptr] = node_ptr->get_notify_guard_condition();
+    weak_nodes_to_guard_conditions_[node_ptr] = node_ptr->get_notify_rclcpp_guard_condition();
     return true;
   }
   return false;
@@ -429,8 +426,9 @@ StaticExecutorEntitiesCollector::is_ready(rcl_wait_set_t * p_wait_set)
       auto found_guard_condition = std::find_if(
         weak_nodes_to_guard_conditions_.begin(), weak_nodes_to_guard_conditions_.end(),
         [&](std::pair<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr,
-        const rcl_guard_condition_t *> pair) -> bool {
-          return pair.second == p_wait_set->guard_conditions[i];
+        const GuardCondition *> pair) -> bool {
+          const rcl_guard_condition_t & rcl_gc = pair.second->get_rcl_guard_condition();
+          return &rcl_gc == p_wait_set->guard_conditions[i];
         });
       if (found_guard_condition != weak_nodes_to_guard_conditions_.end()) {
         return true;

--- a/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
@@ -60,9 +60,7 @@ StaticSingleThreadedExecutor::add_callback_group(
   bool is_new_node = entities_collector_->add_callback_group(group_ptr, node_ptr);
   if (is_new_node && notify) {
     // Interrupt waiting to handle new node
-    if (rcl_trigger_guard_condition(&interrupt_guard_condition_) != RCL_RET_OK) {
-      throw std::runtime_error(rcl_get_error_string().str);
-    }
+    interrupt_guard_condition_.trigger();
   }
 }
 
@@ -73,9 +71,7 @@ StaticSingleThreadedExecutor::add_node(
   bool is_new_node = entities_collector_->add_node(node_ptr);
   if (is_new_node && notify) {
     // Interrupt waiting to handle new node
-    if (rcl_trigger_guard_condition(&interrupt_guard_condition_) != RCL_RET_OK) {
-      throw std::runtime_error(rcl_get_error_string().str);
-    }
+    interrupt_guard_condition_.trigger();
   }
 }
 
@@ -92,9 +88,7 @@ StaticSingleThreadedExecutor::remove_callback_group(
   bool node_removed = entities_collector_->remove_callback_group(group_ptr);
   // If the node was matched and removed, interrupt waiting
   if (node_removed && notify) {
-    if (rcl_trigger_guard_condition(&interrupt_guard_condition_) != RCL_RET_OK) {
-      throw std::runtime_error(rcl_get_error_string().str);
-    }
+    interrupt_guard_condition_.trigger();
   }
 }
 
@@ -108,9 +102,7 @@ StaticSingleThreadedExecutor::remove_node(
   }
   // If the node was matched and removed, interrupt waiting
   if (notify) {
-    if (rcl_trigger_guard_condition(&interrupt_guard_condition_) != RCL_RET_OK) {
-      throw std::runtime_error(rcl_get_error_string().str);
-    }
+    interrupt_guard_condition_.trigger();
   }
 }
 

--- a/rclcpp/src/rclcpp/graph_listener.cpp
+++ b/rclcpp/src/rclcpp/graph_listener.cpp
@@ -40,19 +40,9 @@ GraphListener::GraphListener(const std::shared_ptr<Context> & parent_context)
 : weak_parent_context_(parent_context),
   rcl_parent_context_(parent_context->get_rcl_context()),
   is_started_(false),
-  is_shutdown_(false)
+  is_shutdown_(false),
+  interrupt_guard_condition_(parent_context)
 {
-  // TODO(wjwwood): make a guard condition class in rclcpp so this can be tracked
-  //   automatically with the rcl guard condition
-  // hold on to this context to prevent it from going out of scope while this
-  // guard condition is using it.
-  rcl_ret_t ret = rcl_guard_condition_init(
-    &interrupt_guard_condition_,
-    rcl_parent_context_.get(),
-    rcl_guard_condition_get_default_options());
-  if (RCL_RET_OK != ret) {
-    throw_from_rcl_error(ret, "failed to create interrupt guard condition");
-  }
 }
 
 GraphListener::~GraphListener()
@@ -159,10 +149,7 @@ GraphListener::run_loop()
       throw_from_rcl_error(ret, "failed to clear wait set");
     }
     // Put the interrupt guard condition in the wait set.
-    ret = rcl_wait_set_add_guard_condition(&wait_set_, &interrupt_guard_condition_, NULL);
-    if (RCL_RET_OK != ret) {
-      throw_from_rcl_error(ret, "failed to add interrupt guard condition to wait set");
-    }
+    interrupt_guard_condition_.add_to_wait_set(&wait_set_);
 
     // Put graph guard conditions for each node into the wait set.
     std::vector<size_t> graph_gc_indexes(node_graph_interfaces_size, 0u);
@@ -211,19 +198,16 @@ GraphListener::run_loop()
 }
 
 static void
-interrupt_(rcl_guard_condition_t * interrupt_guard_condition)
+interrupt_(GuardCondition * interrupt_guard_condition)
 {
-  rcl_ret_t ret = rcl_trigger_guard_condition(interrupt_guard_condition);
-  if (RCL_RET_OK != ret) {
-    throw_from_rcl_error(ret, "failed to trigger the interrupt guard condition");
-  }
+  interrupt_guard_condition->trigger();
 }
 
 static void
 acquire_nodes_lock_(
   std::mutex * node_graph_interfaces_barrier_mutex,
   std::mutex * node_graph_interfaces_mutex,
-  rcl_guard_condition_t * interrupt_guard_condition)
+  GuardCondition * interrupt_guard_condition)
 {
   {
     // Acquire this lock to prevent the run loop from re-locking the
@@ -350,10 +334,6 @@ GraphListener::__shutdown()
     if (is_started_) {
       interrupt_(&interrupt_guard_condition_);
       listener_thread_.join();
-    }
-    rcl_ret_t ret = rcl_guard_condition_fini(&interrupt_guard_condition_);
-    if (RCL_RET_OK != ret) {
-      throw_from_rcl_error(ret, "failed to finalize interrupt guard condition");
     }
     if (is_started_) {
       cleanup_wait_set();

--- a/rclcpp/src/rclcpp/guard_condition.cpp
+++ b/rclcpp/src/rclcpp/guard_condition.cpp
@@ -96,13 +96,18 @@ GuardCondition::add_to_wait_set(rcl_wait_set_t * wait_set) const
 }
 
 void
-GuardCondition::set_on_trigger_callback(std::function<void(size_t, int)> callback)
+GuardCondition::set_on_trigger_callback(std::function<void(size_t)> callback)
 {
-  on_trigger_callback_ = std::bind(callback, std::placeholders::_1, -1);
+  if (callback) {
+    on_trigger_callback_ = callback;
 
-  if (unread_count_) {
-    on_trigger_callback_(unread_count_);
-    unread_count_ = 0;
+    if (unread_count_) {
+      callback(unread_count_);
+      unread_count_ = 0;
+    }
+    return;
   }
+
+  on_trigger_callback_ = nullptr;
 }
 }  // namespace rclcpp

--- a/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
@@ -348,13 +348,7 @@ NodeGraph::notify_graph_change()
     }
   }
   graph_cv_.notify_all();
-  {
-    auto notify_condition_lock = node_base_->acquire_notify_guard_condition_lock();
-    rcl_ret_t ret = rcl_trigger_guard_condition(node_base_->get_notify_guard_condition());
-    if (RCL_RET_OK != ret) {
-      throw_from_rcl_error(ret, "failed to trigger notify guard condition");
-    }
-  }
+  node_base_->trigger_notify_guard_condition();
 }
 
 void

--- a/rclcpp/src/rclcpp/node_interfaces/node_services.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_services.cpp
@@ -41,15 +41,7 @@ NodeServices::add_service(
   }
 
   // Notify the executor that a new service was created using the parent Node.
-  {
-    auto notify_guard_condition_lock = node_base_->acquire_notify_guard_condition_lock();
-    if (rcl_trigger_guard_condition(node_base_->get_notify_guard_condition()) != RCL_RET_OK) {
-      throw std::runtime_error(
-              std::string("Failed to notify wait set on service creation: ") +
-              rmw_get_error_string().str
-      );
-    }
-  }
+  node_base_->trigger_notify_guard_condition();
 }
 
 void
@@ -68,15 +60,7 @@ NodeServices::add_client(
   }
 
   // Notify the executor that a new client was created using the parent Node.
-  {
-    auto notify_guard_condition_lock = node_base_->acquire_notify_guard_condition_lock();
-    if (rcl_trigger_guard_condition(node_base_->get_notify_guard_condition()) != RCL_RET_OK) {
-      throw std::runtime_error(
-              std::string("Failed to notify wait set on client creation: ") +
-              rmw_get_error_string().str
-      );
-    }
-  }
+  node_base_->trigger_notify_guard_condition();
 }
 
 std::string

--- a/rclcpp/src/rclcpp/node_interfaces/node_timers.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_timers.cpp
@@ -41,11 +41,9 @@ NodeTimers::add_timer(
   } else {
     node_base_->get_default_callback_group()->add_timer(timer);
   }
-  if (rcl_trigger_guard_condition(node_base_->get_notify_guard_condition()) != RCL_RET_OK) {
-    throw std::runtime_error(
-            std::string("Failed to notify wait set on timer creation: ") +
-            rmw_get_error_string().str);
-  }
+
+  node_base_->trigger_notify_guard_condition();
+
   TRACEPOINT(
     rclcpp_timer_link_node,
     static_cast<const void *>(timer->get_timer_handle().get()),

--- a/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
@@ -60,14 +60,7 @@ NodeTopics::add_publisher(
   }
 
   // Notify the executor that a new publisher was created using the parent Node.
-  {
-    auto notify_guard_condition_lock = node_base_->acquire_notify_guard_condition_lock();
-    if (rcl_trigger_guard_condition(node_base_->get_notify_guard_condition()) != RCL_RET_OK) {
-      throw std::runtime_error(
-              std::string("Failed to notify wait set on publisher creation: ") +
-              rmw_get_error_string().str);
-    }
-  }
+  node_base_->trigger_notify_guard_condition();
 }
 
 rclcpp::SubscriptionBase::SharedPtr
@@ -108,14 +101,7 @@ NodeTopics::add_subscription(
   }
 
   // Notify the executor that a new subscription was created using the parent Node.
-  {
-    auto notify_guard_condition_lock = node_base_->acquire_notify_guard_condition_lock();
-    auto ret = rcl_trigger_guard_condition(node_base_->get_notify_guard_condition());
-    if (ret != RCL_RET_OK) {
-      using rclcpp::exceptions::throw_from_rcl_error;
-      throw_from_rcl_error(ret, "failed to notify wait set on subscription creation");
-    }
-  }
+  node_base_->trigger_notify_guard_condition();
 }
 
 rclcpp::node_interfaces::NodeBaseInterface *

--- a/rclcpp/src/rclcpp/node_interfaces/node_waitables.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_waitables.cpp
@@ -41,15 +41,7 @@ NodeWaitables::add_waitable(
   }
 
   // Notify the executor that a new waitable was created using the parent Node.
-  {
-    auto notify_guard_condition_lock = node_base_->acquire_notify_guard_condition_lock();
-    if (rcl_trigger_guard_condition(node_base_->get_notify_guard_condition()) != RCL_RET_OK) {
-      throw std::runtime_error(
-              std::string("Failed to notify wait set on waitable creation: ") +
-              rmw_get_error_string().str
-      );
-    }
-  }
+  node_base_->trigger_notify_guard_condition();
 }
 
 void

--- a/rclcpp/src/rclcpp/qos_event.cpp
+++ b/rclcpp/src/rclcpp/qos_event.cpp
@@ -85,11 +85,9 @@ QOSEventHandlerBase::set_on_new_event_callback(
 }
 
 void
-QOSEventHandlerBase::set_listener_callback(
-  rmw_listener_callback_t callback,
-  const void * user_data)
+QOSEventHandlerBase::set_listener_callback(std::function<void(size_t, int)> callback)
 {
-  set_on_new_event_callback(callback, user_data);
+  // set_on_new_event_callback(callback);
 }
 
 

--- a/rclcpp/src/rclcpp/qos_event.cpp
+++ b/rclcpp/src/rclcpp/qos_event.cpp
@@ -69,17 +69,18 @@ QOSEventHandlerBase::is_ready(rcl_wait_set_t * wait_set)
 }
 
 void
-QOSEventHandlerBase::set_listener_callback(
-  rmw_listener_callback_t callback,
-  const void * user_data) const
+QOSEventHandlerBase::set_on_new_event_callback(
+  rcl_event_callback_t callback,
+  const void * user_data)
 {
-  rcl_ret_t ret = rcl_event_set_listener_callback(
+  rcl_ret_t ret = rcl_event_set_callback(
     &event_handle_,
     callback,
     user_data);
 
   if (RCL_RET_OK != ret) {
-    throw std::runtime_error("Couldn't set listener callback to QOSEventHandlerBase");
+    using rclcpp::exceptions::throw_from_rcl_error;
+    throw_from_rcl_error(ret, "failed to set the on new message callback for subscription");
   }
 }
 

--- a/rclcpp/src/rclcpp/qos_event.cpp
+++ b/rclcpp/src/rclcpp/qos_event.cpp
@@ -84,4 +84,13 @@ QOSEventHandlerBase::set_on_new_event_callback(
   }
 }
 
+void
+QOSEventHandlerBase::set_listener_callback(
+  rmw_listener_callback_t callback,
+  const void * user_data)
+{
+  set_on_new_event_callback(callback, user_data);
+}
+
+
 }  // namespace rclcpp

--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -28,7 +28,8 @@
 using rclcpp::ServiceBase;
 
 ServiceBase::ServiceBase(std::shared_ptr<rcl_node_t> node_handle)
-: node_handle_(node_handle)
+: node_handle_(node_handle),
+  node_logger_(rclcpp::get_node_logger(node_handle_.get()))
 {}
 
 ServiceBase::~ServiceBase()
@@ -86,16 +87,15 @@ ServiceBase::exchange_in_use_by_wait_set_state(bool in_use_state)
 }
 
 void
-ServiceBase::set_listener_callback(
-  rmw_listener_callback_t callback,
-  const void * user_data) const
+ServiceBase::set_on_new_request_callback(rcl_event_callback_t callback, const void * user_data)
 {
-  rcl_ret_t ret = rcl_service_set_listener_callback(
+  rcl_ret_t ret = rcl_service_set_on_new_request_callback(
     service_handle_.get(),
     callback,
     user_data);
 
   if (RCL_RET_OK != ret) {
-    throw std::runtime_error("Couldn't set listener callback to service");
+    using rclcpp::exceptions::throw_from_rcl_error;
+    throw_from_rcl_error(ret, "failed to set the on new request callback for service");
   }
 }

--- a/rclcpp/src/rclcpp/subscription_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_base.cpp
@@ -39,6 +39,7 @@ SubscriptionBase::SubscriptionBase(
   bool is_serialized)
 : node_base_(node_base),
   node_handle_(node_base_->get_shared_rcl_node_handle()),
+  node_logger_(rclcpp::get_node_logger(node_handle_.get())),
   use_intra_process_(false),
   intra_process_subscription_id_(0),
   type_support_(type_support_handle),
@@ -290,16 +291,17 @@ SubscriptionBase::exchange_in_use_by_wait_set_state(
 }
 
 void
-SubscriptionBase::set_listener_callback(
-  rmw_listener_callback_t callback,
-  const void * user_data) const
+SubscriptionBase::set_on_new_message_callback(
+  rcl_event_callback_t callback,
+  const void * user_data)
 {
-  rcl_ret_t ret = rcl_subscription_set_listener_callback(
+  rcl_ret_t ret = rcl_subscription_set_on_new_message_callback(
     subscription_handle_.get(),
     callback,
     user_data);
 
   if (RCL_RET_OK != ret) {
-    throw std::runtime_error("Couldn't set listener callback to subscription");
+    using rclcpp::exceptions::throw_from_rcl_error;
+    throw_from_rcl_error(ret, "failed to set the on new message callback for subscription");
   }
 }

--- a/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
@@ -41,7 +41,7 @@ SubscriptionIntraProcessBase::get_actual_qos() const
 void
 SubscriptionIntraProcessBase::set_listener_callback(
   rmw_listener_callback_t callback,
-  const void * user_data) const
+  const void * user_data)
 {
   (void)callback;
   (void)user_data;

--- a/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <functional>
+
 #include "rclcpp/experimental/subscription_intra_process_base.hpp"
 
 using rclcpp::experimental::SubscriptionIntraProcessBase;
@@ -41,5 +43,10 @@ SubscriptionIntraProcessBase::get_actual_qos() const
 void
 SubscriptionIntraProcessBase::set_listener_callback(std::function<void(size_t, int)> callback)
 {
-  (void)callback;
+  on_new_message_callback_ = std::bind(callback, std::placeholders::_1, -1);
+
+  if (unread_count_ && on_new_message_callback_) {
+    on_new_message_callback_(unread_count_);
+    unread_count_ = 0;
+  }
 }

--- a/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
@@ -21,8 +21,9 @@ SubscriptionIntraProcessBase::add_to_wait_set(rcl_wait_set_t * wait_set)
 {
   std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
 
-  rcl_ret_t ret = rcl_wait_set_add_guard_condition(wait_set, &gc_, NULL);
-  return RCL_RET_OK == ret;
+  gc_.add_to_wait_set(wait_set);
+
+  return true;
 }
 
 const char *

--- a/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
@@ -39,10 +39,7 @@ SubscriptionIntraProcessBase::get_actual_qos() const
 }
 
 void
-SubscriptionIntraProcessBase::set_listener_callback(
-  rmw_listener_callback_t callback,
-  const void * user_data)
+SubscriptionIntraProcessBase::set_listener_callback(std::function<void(size_t, int)> callback)
 {
   (void)callback;
-  (void)user_data;
 }

--- a/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
@@ -43,12 +43,6 @@ SubscriptionIntraProcessBase::set_listener_callback(
   rmw_listener_callback_t callback,
   const void * user_data) const
 {
-  rcl_ret_t ret = rcl_guard_condition_set_listener_callback(
-    &gc_,
-    callback,
-    user_data);
-
-  if (RCL_RET_OK != ret) {
-    throw std::runtime_error("Couldn't set guard condition listener callback");
-  }
+  (void)callback;
+  (void)user_data;
 }

--- a/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
@@ -43,10 +43,18 @@ SubscriptionIntraProcessBase::get_actual_qos() const
 void
 SubscriptionIntraProcessBase::set_listener_callback(std::function<void(size_t, int)> callback)
 {
-  on_new_message_callback_ = std::bind(callback, std::placeholders::_1, -1);
-
-  if (unread_count_ && on_new_message_callback_) {
-    on_new_message_callback_(unread_count_);
-    unread_count_ = 0;
+  if (callback) {
+    on_new_message_callback_ = std::bind(callback, std::placeholders::_1, -1);
+      if (unread_count_) {
+        if (unread_count_ < qos_profile_.depth) {
+          on_new_message_callback_(unread_count_);
+        } else {
+          on_new_message_callback_(qos_profile_.depth);
+        }
+        unread_count_ = 0;
+      }
+    return;
   }
+
+  on_new_message_callback_ = nullptr;
 }

--- a/rclcpp/src/rclcpp/waitable.cpp
+++ b/rclcpp/src/rclcpp/waitable.cpp
@@ -63,7 +63,7 @@ Waitable::exchange_in_use_by_wait_set_state(bool in_use_state)
 void
 Waitable::set_listener_callback(
   rmw_listener_callback_t callback,
-  const void * user_data) const
+  const void * user_data)
 {
   (void)callback;
   (void)user_data;

--- a/rclcpp/src/rclcpp/waitable.cpp
+++ b/rclcpp/src/rclcpp/waitable.cpp
@@ -61,12 +61,9 @@ Waitable::exchange_in_use_by_wait_set_state(bool in_use_state)
 }
 
 void
-Waitable::set_listener_callback(
-  rmw_listener_callback_t callback,
-  const void * user_data)
+Waitable::set_listener_callback(std::function<void(size_t, int)> callback)
 {
   (void)callback;
-  (void)user_data;
 
   throw std::runtime_error(
           "Custom waitables should override set_listener_callback() "

--- a/rclcpp/test/benchmark/benchmark_executor.cpp
+++ b/rclcpp/test/benchmark/benchmark_executor.cpp
@@ -376,9 +376,8 @@ BENCHMARK_F(
 
   auto memory_strategy = rclcpp::memory_strategies::create_default_strategy();
   rclcpp::GuardCondition guard_condition(shared_context);
-  rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
 
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->init(&wait_set, memory_strategy, &guard_condition);
   RCLCPP_SCOPE_EXIT(entities_collector_->fini());
 
   reset_heap_counters();

--- a/rclcpp/test/rclcpp/executors/test_events_executor.cpp
+++ b/rclcpp/test/rclcpp/executors/test_events_executor.cpp
@@ -52,12 +52,6 @@ TEST_F(TestEventsExecutor, notify_waitable)
   rcl_wait_set_t wait_set = rcl_get_zero_initialized_wait_set();
   EXPECT_THROW(notifier->add_to_wait_set(&wait_set), std::runtime_error);
   EXPECT_THROW(notifier->is_ready(&wait_set), std::runtime_error);
-
-  {
-    auto mock = mocking_utils::patch_and_return(
-      "lib:rclcpp", rcl_guard_condition_set_listener_callback, RCL_RET_ERROR);
-    EXPECT_THROW(std::make_shared<EventsExecutor>(), std::runtime_error);
-  }
 }
 
 TEST_F(TestEventsExecutor, run_clients_servers)

--- a/rclcpp/test/rclcpp/executors/test_events_executor_entities_collector.cpp
+++ b/rclcpp/test/rclcpp/executors/test_events_executor_entities_collector.cpp
@@ -156,23 +156,3 @@ TEST_F(TestEventsExecutorEntitiesCollector, remove_node_opposite_order)
 
   EXPECT_NO_THROW(entities_collector_->remove_node(node2->get_node_base_interface()));
 }
-
-TEST_F(TestEventsExecutorEntitiesCollector, test_rcl_exception)
-{
-  auto node1 = std::make_shared<rclcpp::Node>("node1", "ns");
-  auto node2 = std::make_shared<rclcpp::Node>("node2", "ns");
-  entities_collector_->add_node(node1->get_node_base_interface());
-
-  {
-    auto mock = mocking_utils::patch_and_return(
-      "lib:rclcpp", rcl_guard_condition_set_listener_callback, RCL_RET_ERROR);
-
-    EXPECT_THROW(
-      entities_collector_->add_node(node2->get_node_base_interface()),
-      std::runtime_error);
-
-    EXPECT_THROW(
-      entities_collector_->remove_node(node1->get_node_base_interface()),
-      std::runtime_error);
-  }
-}

--- a/rclcpp/test/rclcpp/executors/test_events_queue.cpp
+++ b/rclcpp/test/rclcpp/executors/test_events_queue.cpp
@@ -60,6 +60,6 @@ TEST(TestEventsQueue, SimpleQueueTest)
   rclcpp::executors::ExecutorEvent front_event = simple_queue->front();
 
   // The events should be equal
-  EXPECT_EQ(push_event.entity_id, front_event.entity_id);
+  EXPECT_EQ(push_event.exec_entity_id, front_event.exec_entity_id);
   EXPECT_EQ(push_event.type, front_event.type);
 }

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -449,7 +449,7 @@ public:
   void
   set_listener_callback(
     rmw_listener_callback_t callback,
-    const void * user_data) const override
+    const void * user_data) override
   {
     rcl_ret_t ret = rcl_guard_condition_set_listener_callback(
       &gc_, callback, user_data);

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -31,6 +31,7 @@
 #include "rcl/time.h"
 #include "rclcpp/clock.hpp"
 #include "rclcpp/duration.hpp"
+#include "rclcpp/guard_condition.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include "test_msgs/msg/empty.hpp"
@@ -401,40 +402,18 @@ TYPED_TEST(TestExecutors, testSpinUntilFutureCompleteInterrupted) {
 class TestWaitable : public rclcpp::Waitable
 {
 public:
-  TestWaitable()
-  {
-    rcl_guard_condition_options_t guard_condition_options =
-      rcl_guard_condition_get_default_options();
-
-    gc_ = rcl_get_zero_initialized_guard_condition();
-    rcl_ret_t ret = rcl_guard_condition_init(
-      &gc_,
-      rclcpp::contexts::get_global_default_context()->get_rcl_context().get(),
-      guard_condition_options);
-    if (RCL_RET_OK != ret) {
-      rclcpp::exceptions::throw_from_rcl_error(ret);
-    }
-  }
-
-  ~TestWaitable()
-  {
-    rcl_ret_t ret = rcl_guard_condition_fini(&gc_);
-    if (RCL_RET_OK != ret) {
-      fprintf(stderr, "failed to call rcl_guard_condition_fini\n");
-    }
-  }
+  TestWaitable() = default;
 
   bool
   add_to_wait_set(rcl_wait_set_t * wait_set) override
   {
-    rcl_ret_t ret = rcl_wait_set_add_guard_condition(wait_set, &gc_, NULL);
-    return RCL_RET_OK == ret;
+    gc_.add_to_wait_set(wait_set);
+    return true;
   }
 
-  bool trigger()
+  void trigger()
   {
-    rcl_ret_t ret = rcl_trigger_guard_condition(&gc_);
-    return RCL_RET_OK == ret;
+    gc_.trigger();
   }
 
   bool
@@ -482,7 +461,7 @@ public:
 
 private:
   size_t count_ = 0;
-  rcl_guard_condition_t gc_;
+  rclcpp::GuardCondition gc_;
 };
 
 TYPED_TEST(TestExecutorsStable, spinAll) {

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -447,16 +447,8 @@ public:
   }
 
   void
-  set_listener_callback(
-    rmw_listener_callback_t callback,
-    const void * user_data) override
+  set_listener_callback(std::function<void(size_t, int)> callback) override
   {
-    rcl_ret_t ret = rcl_guard_condition_set_listener_callback(
-      &gc_, callback, user_data);
-
-    if (RCL_RET_OK != ret) {
-      throw std::runtime_error(std::string("Couldn't set guard condition callback"));
-    }
   }
 
 private:

--- a/rclcpp/test/rclcpp/executors/test_static_executor_entities_collector.cpp
+++ b/rclcpp/test/rclcpp/executors/test_static_executor_entities_collector.cpp
@@ -141,12 +141,11 @@ TEST_F(TestStaticExecutorEntitiesCollector, init_bad_arguments) {
   RCLCPP_SCOPE_EXIT({EXPECT_EQ(RCL_RET_OK, rcl_wait_set_fini(&wait_set));});
 
   rclcpp::GuardCondition guard_condition(shared_context);
-  rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
 
   // Check memory strategy is nullptr
   rclcpp::memory_strategy::MemoryStrategy::SharedPtr memory_strategy = nullptr;
   EXPECT_THROW(
-    entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition),
+    entities_collector_->init(&wait_set, memory_strategy, &guard_condition),
     std::runtime_error);
 }
 
@@ -167,9 +166,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_remove_basic_node) {
 
   auto memory_strategy = rclcpp::memory_strategies::create_default_strategy();
   rclcpp::GuardCondition guard_condition(shared_context);
-  rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
-
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->init(&wait_set, memory_strategy, &guard_condition);
   RCLCPP_SCOPE_EXIT(entities_collector_->fini());
   EXPECT_EQ(
     expected_number_of_entities->subscriptions,
@@ -183,7 +180,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_remove_basic_node) {
     entities_collector_->get_number_of_waitables());
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->init(&wait_set, memory_strategy, &guard_condition);
   EXPECT_EQ(0u, entities_collector_->get_number_of_subscriptions());
   EXPECT_EQ(0u, entities_collector_->get_number_of_timers());
   EXPECT_EQ(0u, entities_collector_->get_number_of_services());
@@ -214,10 +211,9 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_remove_node_out_of_scope) {
 
   auto memory_strategy = rclcpp::memory_strategies::create_default_strategy();
   rclcpp::GuardCondition guard_condition(shared_context);
-  rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
 
   // Expect weak_node pointers to be cleaned up and used
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->init(&wait_set, memory_strategy, &guard_condition);
   RCLCPP_SCOPE_EXIT(entities_collector_->fini());
   EXPECT_EQ(0u, entities_collector_->get_number_of_subscriptions());
   EXPECT_EQ(0u, entities_collector_->get_number_of_timers());
@@ -286,9 +282,8 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_remove_node_with_entities) {
   auto memory_strategy = rclcpp::memory_strategies::create_default_strategy();
 
   rclcpp::GuardCondition guard_condition(shared_context);
-  rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
 
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->init(&wait_set, memory_strategy, &guard_condition);
   RCLCPP_SCOPE_EXIT(entities_collector_->fini());
 
   EXPECT_EQ(
@@ -308,7 +303,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_remove_node_with_entities) {
     entities_collector_->get_number_of_waitables());
 
   entities_collector_->remove_node(node->get_node_base_interface());
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->init(&wait_set, memory_strategy, &guard_condition);
   EXPECT_EQ(0u, entities_collector_->get_number_of_subscriptions());
   EXPECT_EQ(0u, entities_collector_->get_number_of_timers());
   EXPECT_EQ(0u, entities_collector_->get_number_of_services());
@@ -365,9 +360,8 @@ TEST_F(TestStaticExecutorEntitiesCollector, prepare_wait_set_rcl_wait_set_clear_
 
   auto memory_strategy = rclcpp::memory_strategies::create_default_strategy();
   rclcpp::GuardCondition guard_condition(shared_context);
-  rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
 
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->init(&wait_set, memory_strategy, &guard_condition);
   RCLCPP_SCOPE_EXIT(entities_collector_->fini());
 
   {
@@ -396,9 +390,8 @@ TEST_F(TestStaticExecutorEntitiesCollector, prepare_wait_set_rcl_wait_set_resize
 
   auto memory_strategy = rclcpp::memory_strategies::create_default_strategy();
   rclcpp::GuardCondition guard_condition(shared_context);
-  rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
 
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->init(&wait_set, memory_strategy, &guard_condition);
   RCLCPP_SCOPE_EXIT(entities_collector_->fini());
 
   {
@@ -434,9 +427,8 @@ TEST_F(TestStaticExecutorEntitiesCollector, refresh_wait_set_rcl_wait_failed) {
 
   auto memory_strategy = rclcpp::memory_strategies::create_default_strategy();
   rclcpp::GuardCondition guard_condition(shared_context);
-  rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
 
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->init(&wait_set, memory_strategy, &guard_condition);
   RCLCPP_SCOPE_EXIT(entities_collector_->fini());
 
   {
@@ -483,9 +475,8 @@ TEST_F(TestStaticExecutorEntitiesCollector, refresh_wait_set_add_handles_to_wait
   auto memory_strategy = rclcpp::memory_strategies::create_default_strategy();
 
   rclcpp::GuardCondition guard_condition(shared_context);
-  rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
 
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->init(&wait_set, memory_strategy, &guard_condition);
   RCLCPP_SCOPE_EXIT(entities_collector_->fini());
 
   {
@@ -515,14 +506,13 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_to_wait_set_nullptr) {
 
   auto memory_strategy = rclcpp::memory_strategies::create_default_strategy();
   rclcpp::GuardCondition guard_condition(shared_context);
-  rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
 
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->init(&wait_set, memory_strategy, &guard_condition);
   RCLCPP_SCOPE_EXIT(entities_collector_->fini());
 
-  RCLCPP_EXPECT_THROW_EQ(
+  EXPECT_THROW(
     entities_collector_->add_to_wait_set(nullptr),
-    std::runtime_error("Executor waitable: couldn't add guard condition to wait set"));
+    std::invalid_argument);
   rcl_reset_error();
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
@@ -543,7 +533,6 @@ TEST_F(TestStaticExecutorEntitiesCollector, fill_memory_strategy_invalid_group) 
 
   auto memory_strategy = rclcpp::memory_strategies::create_default_strategy();
   rclcpp::GuardCondition guard_condition(shared_context);
-  rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
 
   rclcpp::CallbackGroup::SharedPtr cb_group = node->create_callback_group(
     rclcpp::CallbackGroupType::MutuallyExclusive);
@@ -553,7 +542,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, fill_memory_strategy_invalid_group) 
 
   cb_group.reset();
 
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->init(&wait_set, memory_strategy, &guard_condition);
   RCLCPP_SCOPE_EXIT(entities_collector_->fini());
   ASSERT_EQ(entities_collector_->get_all_callback_groups().size(), 1u);
 
@@ -621,9 +610,8 @@ TEST_F(
 
   auto memory_strategy = rclcpp::memory_strategies::create_default_strategy();
   rclcpp::GuardCondition guard_condition(shared_context);
-  rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
 
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->init(&wait_set, memory_strategy, &guard_condition);
   RCLCPP_SCOPE_EXIT(entities_collector_->fini());
 
   cb_group->get_associated_with_executor_atomic().exchange(false);

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_services.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_services.cpp
@@ -103,7 +103,7 @@ TEST_F(TestNodeService, add_service_rcl_trigger_guard_condition_error)
     "lib:rclcpp", rcl_trigger_guard_condition, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     node_services->add_service(service, callback_group),
-    std::runtime_error("Failed to notify wait set on service creation: error not set"));
+    std::runtime_error("error not set"));
 }
 
 TEST_F(TestNodeService, add_client)
@@ -130,7 +130,7 @@ TEST_F(TestNodeService, add_client_rcl_trigger_guard_condition_error)
     "lib:rclcpp", rcl_trigger_guard_condition, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     node_services->add_client(client, callback_group),
-    std::runtime_error("Failed to notify wait set on client creation: error not set"));
+    std::runtime_error("error not set"));
 }
 
 TEST_F(TestNodeService, resolve_service_name)

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_timers.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_timers.cpp
@@ -86,5 +86,5 @@ TEST_F(TestNodeTimers, add_timer_rcl_trigger_guard_condition_error)
     "lib:rclcpp", rcl_trigger_guard_condition, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     node_timers->add_timer(timer, callback_group),
-    std::runtime_error("Failed to notify wait set on timer creation: error not set"));
+    std::runtime_error("error not set"));
 }

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_topics.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_topics.cpp
@@ -127,7 +127,7 @@ TEST_F(TestNodeTopics, add_publisher_rcl_trigger_guard_condition_error)
     "lib:rclcpp", rcl_trigger_guard_condition, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     node_topics->add_publisher(publisher, callback_group),
-    std::runtime_error("Failed to notify wait set on publisher creation: error not set"));
+    std::runtime_error("error not set"));
 }
 
 TEST_F(TestNodeTopics, add_subscription)
@@ -155,7 +155,7 @@ TEST_F(TestNodeTopics, add_subscription_rcl_trigger_guard_condition_error)
     "lib:rclcpp", rcl_trigger_guard_condition, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     node_topics->add_subscription(subscription, callback_group),
-    std::runtime_error("failed to notify wait set on subscription creation: error not set"));
+    std::runtime_error("error not set"));
 }
 
 TEST_F(TestNodeTopics, resolve_topic_name)

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_waitables.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_waitables.cpp
@@ -96,5 +96,5 @@ TEST_F(TestNodeWaitables, add_waitable_rcl_trigger_guard_condition_error)
     "lib:rclcpp", rcl_trigger_guard_condition, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     node_waitables->add_waitable(waitable, callback_group),
-    std::runtime_error("Failed to notify wait set on waitable creation: error not set"));
+    std::runtime_error("error not set"));
 }

--- a/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
@@ -468,9 +468,9 @@ TEST_F(TestAllocatorMemoryStrategy, construct_destruct) {
 }
 
 TEST_F(TestAllocatorMemoryStrategy, add_remove_guard_conditions) {
-  rcl_guard_condition_t guard_condition1 = rcl_get_zero_initialized_guard_condition();
-  rcl_guard_condition_t guard_condition2 = rcl_get_zero_initialized_guard_condition();
-  rcl_guard_condition_t guard_condition3 = rcl_get_zero_initialized_guard_condition();
+  rclcpp::GuardCondition guard_condition1;
+  rclcpp::GuardCondition guard_condition2;
+  rclcpp::GuardCondition guard_condition3;
 
   EXPECT_NO_THROW(allocator_memory_strategy()->add_guard_condition(&guard_condition1));
   EXPECT_NO_THROW(allocator_memory_strategy()->add_guard_condition(&guard_condition2));
@@ -586,24 +586,17 @@ TEST_F(TestAllocatorMemoryStrategy, add_handles_to_wait_set_client) {
 
 TEST_F(TestAllocatorMemoryStrategy, add_handles_to_wait_set_guard_condition) {
   auto node = create_node_with_disabled_callback_groups("node");
-  rcl_guard_condition_t guard_condition = rcl_get_zero_initialized_guard_condition();
   auto context = node->get_node_base_interface()->get_context();
-  rcl_context_t * rcl_context = context->get_rcl_context().get();
-  rcl_guard_condition_options_t guard_condition_options = {
-    rcl_get_default_allocator()};
 
-  EXPECT_EQ(
-    RCL_RET_OK,
-    rcl_guard_condition_init(&guard_condition, rcl_context, guard_condition_options));
-  RCLCPP_SCOPE_EXIT(
-  {
-    EXPECT_EQ(RCL_RET_OK, rcl_guard_condition_fini(&guard_condition));
-  });
+  rclcpp::GuardCondition guard_condition(context);
+
+  EXPECT_NO_THROW(rclcpp::GuardCondition guard_condition(context););
 
   allocator_memory_strategy()->add_guard_condition(&guard_condition);
+
   RclWaitSetSizes insufficient_capacities = SufficientWaitSetCapacities();
   insufficient_capacities.size_of_guard_conditions = 0;
-  EXPECT_TRUE(TestAddHandlesToWaitSet(node, insufficient_capacities));
+  EXPECT_THROW(TestAddHandlesToWaitSet(node, insufficient_capacities), std::runtime_error);
 }
 
 TEST_F(TestAllocatorMemoryStrategy, add_handles_to_wait_set_timer) {

--- a/rclcpp/test/rclcpp/test_executor.cpp
+++ b/rclcpp/test/rclcpp/test_executor.cpp
@@ -155,7 +155,7 @@ TEST_F(TestExecutor, add_callback_group_failed_trigger_guard_condition) {
     "lib:rclcpp", rcl_trigger_guard_condition, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     dummy.add_callback_group(cb_group, node->get_node_base_interface(), true),
-    std::runtime_error("Failed to trigger guard condition on callback group add: error not set"));
+    std::runtime_error("error not set"));
 }
 
 TEST_F(TestExecutor, remove_callback_group_null_node) {
@@ -186,7 +186,7 @@ TEST_F(TestExecutor, remove_callback_group_failed_trigger_guard_condition) {
   RCLCPP_EXPECT_THROW_EQ(
     dummy.remove_callback_group(cb_group, true),
     std::runtime_error(
-      "Failed to trigger guard condition on callback group remove: error not set"));
+      "error not set"));
 }
 
 TEST_F(TestExecutor, remove_node_not_associated) {
@@ -325,7 +325,7 @@ TEST_F(TestExecutor, cancel_failed_trigger_guard_condition) {
     "lib:rclcpp", rcl_trigger_guard_condition, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     dummy.cancel(),
-    std::runtime_error("Failed to trigger guard condition in cancel: error not set"));
+    std::runtime_error("error not set"));
 }
 
 TEST_F(TestExecutor, set_memory_strategy_nullptr) {
@@ -360,7 +360,7 @@ TEST_F(TestExecutor, spin_once_failed_trigger_guard_condition) {
   RCLCPP_EXPECT_THROW_EQ(
     dummy.spin_once(std::chrono::milliseconds(1)),
     std::runtime_error(
-      "Failed to trigger guard condition from execute_any_executable: error not set"));
+      "error not set"));
 }
 
 TEST_F(TestExecutor, spin_some_fail_wait_set_clear) {

--- a/rclcpp/test/rclcpp/test_graph_listener.cpp
+++ b/rclcpp/test/rclcpp/test_graph_listener.cpp
@@ -87,7 +87,7 @@ TEST_F(TestGraphListener, error_construct_graph_listener) {
     auto graph_listener_error =
     std::make_shared<rclcpp::graph_listener::GraphListener>(get_global_default_context());
     graph_listener_error.reset();
-  }, std::runtime_error("failed to create interrupt guard condition: error not set"));
+  }, std::runtime_error("failed to create guard condition: error not set"));
 }
 
 // Required for mocking_utils below
@@ -169,7 +169,7 @@ TEST_F(TestGraphListener, error_run_graph_listener_mock_wait_set_add_guard_condi
     "lib:rclcpp", rcl_wait_set_add_guard_condition, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     graph_listener_test->run_protected(),
-    std::runtime_error("failed to add interrupt guard condition to wait set: error not set"));
+    std::runtime_error("failed to add guard condition to wait set: error not set"));
 }
 
 TEST_F(TestGraphListener, error_run_graph_listener_mock_wait_error) {
@@ -292,9 +292,7 @@ TEST_F(TestGraphListener, test_graph_listener_shutdown_guard_fini_error_throw) {
   auto mock_wait_set_fini = mocking_utils::patch_and_return(
     "lib:rclcpp", rcl_guard_condition_fini, RCL_RET_ERROR);
 
-  RCLCPP_EXPECT_THROW_EQ(
-    graph_listener_test->shutdown(),
-    std::runtime_error("failed to finalize interrupt guard condition: error not set"));
+  EXPECT_NO_THROW(graph_listener_test->shutdown());
 
   graph_listener_test->mock_cleanup_wait_set();
 }


### PR DESCRIPTION
Changes
- Use rclcpp::GuardConditions 53cc25d
- Apply william's refactor to make callbacks type safe 56405fc 
- Use std::function as executor callbacks 1412e94
- Add callback to rclcpp::GuardConditions 32aa3db
- Add callback to rclcpp intra-process subscriptions 7cadae3
- Limit intra-process subscription events to QoS depth size.
- Limit nodes GuardConditions max events to one 41c8f8a