### PR TITLE
Complete support for rmw listener APIs

### DIFF
--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -19,6 +19,7 @@
 #include <future>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <string>
 #include <tuple>
@@ -178,7 +179,6 @@ public:
    *
    * \param[in] callback functor to be called when a new response is received
    */
-  RCLCPP_PUBLIC
   void
   set_on_new_response_callback(std::function<void(size_t)> callback)
   {
@@ -208,6 +208,8 @@ public:
         }
       };
 
+    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
+
     // Set it temporarily to the new callback, while we replace the old one.
     // This two-step setting, prevents a gap where the old std::function has
     // been replaced but the middleware hasn't been told about the new one yet.
@@ -225,10 +227,10 @@ public:
   }
 
   /// Unset the callback registered for new responses, if any.
-  RCLCPP_PUBLIC
   void
   clear_on_new_response_callback()
   {
+    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
     set_on_new_response_callback(nullptr, nullptr);
     on_new_response_callback_ = nullptr;
   }
@@ -261,6 +263,7 @@ protected:
 
   std::atomic<bool> in_use_by_wait_set_{false};
 
+  std::recursive_mutex reentrant_mutex_;
   std::function<void(size_t)> on_new_response_callback_{nullptr};
 };
 

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -165,19 +165,29 @@ public:
    *
    * Calling it again will clear any previously set callback.
    *
+   * An exception will be thrown if the callback is not callable.
+   *
    * This function is thread-safe.
    *
    * If you want more information available in the callback, like the client
    * or other information, you may use a lambda with captures or std::bind.
    *
+   * \sa rclcpp::ClientBase::clear_on_new_response_callback
    * \sa rmw_client_set_on_new_response_callback
    * \sa rcl_client_set_on_new_response_callback
    *
    * \param[in] callback functor to be called when a new response is received
    */
+  RCLCPP_PUBLIC
   void
   set_on_new_response_callback(std::function<void(size_t)> callback)
   {
+    if (!callback) {
+      throw std::invalid_argument(
+              "The callback passed to set_on_new_response_callback "
+              "is not callable.");
+    }
+
     auto new_callback =
       [callback, this](size_t number_of_responses) {
         try {
@@ -214,6 +224,15 @@ public:
       static_cast<const void *>(&on_new_response_callback_));
   }
 
+  /// Unset the callback registered for new responses, if any.
+  RCLCPP_PUBLIC
+  void
+  clear_on_new_response_callback()
+  {
+    set_on_new_response_callback(nullptr, nullptr);
+    on_new_response_callback_ = nullptr;
+  }
+
 protected:
   RCLCPP_DISABLE_COPY(ClientBase)
 
@@ -242,7 +261,7 @@ protected:
 
   std::atomic<bool> in_use_by_wait_set_{false};
 
-  std::function<void(size_t)> on_new_response_callback_;
+  std::function<void(size_t)> on_new_response_callback_{nullptr};
 };
 
 template<typename ServiceT>

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -173,7 +173,6 @@ public:
    * If you want more information available in the callback, like the client
    * or other information, you may use a lambda with captures or std::bind.
    *
-   * \sa rclcpp::ClientBase::clear_on_new_response_callback
    * \sa rmw_client_set_on_new_response_callback
    * \sa rcl_client_set_on_new_response_callback
    *

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
@@ -148,6 +148,7 @@ public:
   provide_intra_process_message(ConstMessageSharedPtr message)
   {
     buffer_->add_shared(std::move(message));
+    invoke_callback();
     trigger_guard_condition();
   }
 
@@ -155,6 +156,7 @@ public:
   provide_intra_process_message(MessageUniquePtr message)
   {
     buffer_->add_unique(std::move(message));
+    invoke_callback();
     trigger_guard_condition();
   }
 
@@ -165,6 +167,17 @@ public:
   }
 
 private:
+  void
+  invoke_callback()
+  {
+    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
+    if (on_new_message_callback_) {
+      on_new_message_callback_(1);
+    } else {
+      unread_count_++;
+    }
+  }
+
   void
   trigger_guard_condition()
   {

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -15,16 +15,16 @@
 #ifndef RCLCPP__EXPERIMENTAL__SUBSCRIPTION_INTRA_PROCESS_BASE_HPP_
 #define RCLCPP__EXPERIMENTAL__SUBSCRIPTION_INTRA_PROCESS_BASE_HPP_
 
-#include <rmw/rmw.h>
-
-#include <functional>
+#include <algorithm>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <utility>
 
 #include "rcl/error_handling.h"
+#include "rmw/impl/cpp/demangle.hpp"
 
+#include "rclcpp/logging.hpp"
 #include "rclcpp/type_support_decl.hpp"
 #include "rclcpp/waitable.hpp"
 
@@ -37,6 +37,11 @@ class SubscriptionIntraProcessBase : public rclcpp::Waitable
 {
 public:
   RCLCPP_SMART_PTR_ALIASES_ONLY(SubscriptionIntraProcessBase)
+
+  enum class EntityType
+  {
+    Subscription,
+  };
 
   RCLCPP_PUBLIC
   SubscriptionIntraProcessBase(const std::string & topic_name, rmw_qos_profile_t qos_profile)
@@ -74,8 +79,94 @@ public:
   rmw_qos_profile_t
   get_actual_qos() const;
 
+  /// Set a callback to be called when each new event instance occurs.
+  /**
+   * The callback receives a size_t which is the number of responses received
+   * since the last time this callback was called.
+   * Normally this is 1, but can be > 1 if responses were received before any
+   * callback was set.
+   *
+   * The callback also receives an int identifier argument.
+   * This is needed because a Waitable may be composed of several distinct entities,
+   * such as subscriptions, services, etc.
+   * The application should provide a generic callback function that will be then
+   * forwarded by the waitable to all of its entities.
+   * Before forwarding, a different value for the identifier argument will be
+   * bounded to the function.
+   * This implies that the provided callback can use the identifier to behave
+   * differently depending on which entity triggered the waitable to become ready.
+   *
+   * Calling it again will clear any previously set callback.
+   *
+   * An exception will be thrown if the callback is not callable.
+   *
+   * This function is thread-safe.
+   *
+   * If you want more information available in the callback, like the client
+   * or other information, you may use a lambda with captures or std::bind.
+   *
+   * Note: this function must be overridden with a proper implementation
+   * by the custom classes who inherit from rclcpp::Waitable if they want to use it.
+   *
+   * \sa rclcpp::SubscriptionIntraProcessBase::clear_on_ready_callback
+   *
+   * \param[in] callback functor to be called when a new message is received.
+   */
+  RCLCPP_PUBLIC
+  void
+  set_on_ready_callback(std::function<void(size_t, int)> callback) override
+  {
+    if (!callback) {
+      throw std::invalid_argument(
+              "The callback passed to set_on_ready_callback "
+              "is not callable.");
+    }
+
+    // Note: we bind the int identifier argument to this waitable's entity types
+    auto new_callback =
+      [callback, this](size_t number_of_events) {
+        try {
+          callback(number_of_events, static_cast<int>(EntityType::Subscription));
+        } catch (const std::exception & exception) {
+          RCLCPP_ERROR_STREAM(
+            // TODO(wjwwood): get this class access to the node logger it is associated with
+            rclcpp::get_logger("rclcpp"),
+            "rclcpp::SubscriptionIntraProcessBase@" << this <<
+              " caught " << rmw::impl::cpp::demangle(exception) <<
+              " exception in user-provided callback for the 'on ready' callback: " <<
+              exception.what());
+        } catch (...) {
+          RCLCPP_ERROR_STREAM(
+            rclcpp::get_logger("rclcpp"),
+            "rclcpp::SubscriptionIntraProcessBase@" << this <<
+              " caught unhandled exception in user-provided callback " <<
+              "for the 'on ready' callback");
+        }
+      };
+
+    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
+    on_new_message_callback_ = new_callback;
+
+    if (unread_count_ > 0) {
+      // Use qos profile depth as upper bound for unread_count_
+      on_new_message_callback_(std::min(unread_count_, qos_profile_.depth));
+      unread_count_ = 0;
+    }
+  }
+
+  /// Unset the callback registered for new messages, if any.
+  RCLCPP_PUBLIC
+  void
+  clear_on_ready_callback() override
+  {
+    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
+    on_new_message_callback_ = nullptr;
+  }
+
 protected:
   std::recursive_mutex reentrant_mutex_;
+  std::function<void(size_t)> on_new_message_callback_ {nullptr};
+  size_t unread_count_{0};
   rcl_guard_condition_t gc_;
 
 private:

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -79,11 +79,11 @@ public:
   rmw_qos_profile_t
   get_actual_qos() const;
 
-  /// Set a callback to be called when each new event instance occurs.
+  /// Set a callback to be called when each new message arrives.
   /**
-   * The callback receives a size_t which is the number of responses received
+   * The callback receives a size_t which is the number of messages received
    * since the last time this callback was called.
-   * Normally this is 1, but can be > 1 if responses were received before any
+   * Normally this is 1, but can be > 1 if messages were received before any
    * callback was set.
    *
    * The callback also receives an int identifier argument.
@@ -92,7 +92,7 @@ public:
    * The application should provide a generic callback function that will be then
    * forwarded by the waitable to all of its entities.
    * Before forwarding, a different value for the identifier argument will be
-   * bounded to the function.
+   * bond to the function.
    * This implies that the provided callback can use the identifier to behave
    * differently depending on which entity triggered the waitable to become ready.
    *
@@ -102,13 +102,8 @@ public:
    *
    * This function is thread-safe.
    *
-   * If you want more information available in the callback, like the client
+   * If you want more information available in the callback, like the subscription
    * or other information, you may use a lambda with captures or std::bind.
-   *
-   * Note: this function must be overridden with a proper implementation
-   * by the custom classes who inherit from rclcpp::Waitable if they want to use it.
-   *
-   * \sa rclcpp::SubscriptionIntraProcessBase::clear_on_ready_callback
    *
    * \param[in] callback functor to be called when a new message is received.
    */

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -112,7 +112,6 @@ public:
    *
    * \param[in] callback functor to be called when a new message is received.
    */
-  RCLCPP_PUBLIC
   void
   set_on_ready_callback(std::function<void(size_t, int)> callback) override
   {

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -149,7 +149,6 @@ public:
   }
 
   /// Unset the callback registered for new messages, if any.
-  RCLCPP_PUBLIC
   void
   clear_on_ready_callback() override
   {

--- a/rclcpp/include/rclcpp/publisher_base.hpp
+++ b/rclcpp/include/rclcpp/publisher_base.hpp
@@ -23,6 +23,8 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "rcl/publisher.h"
@@ -109,9 +111,10 @@ public:
   get_publisher_handle() const;
 
   /// Get all the QoS event handlers associated with this publisher.
-  /** \return The vector of QoS event handlers. */
+  /** \return The map of QoS event handlers. */
   RCLCPP_PUBLIC
-  const std::vector<std::shared_ptr<rclcpp::QOSEventHandlerBase>> &
+  const
+  std::unordered_map<rcl_publisher_event_type_t, std::shared_ptr<rclcpp::QOSEventHandlerBase>> &
   get_event_handlers() const;
 
   /// Get subscription count
@@ -193,6 +196,71 @@ public:
     uint64_t intra_process_publisher_id,
     IntraProcessManagerSharedPtr ipm);
 
+  /// Set a callback to be called when each new qos event instance occurs.
+  /**
+   * The callback receives a size_t which is the number of events that occurred
+   * since the last time this callback was called.
+   * Normally this is 1, but can be > 1 if events occurred before any
+   * callback was set.
+   *
+   * Since this callback is called from the middleware, you should aim to make
+   * it fast and not blocking.
+   * If you need to do a lot of work or wait for some other event, you should
+   * spin it off to another thread, otherwise you risk blocking the middleware.
+   *
+   * Calling it again will clear any previously set callback.
+   *
+   * An exception will be thrown if the callback is not callable.
+   *
+   * This function is thread-safe.
+   *
+   * If you want more information available in the callback, like the qos event
+   * or other information, you may use a lambda with captures or std::bind.
+   *
+   * \sa rclcpp::QOSEventHandlerBase::set_on_ready_callback
+   *
+   * \param[in] callback functor to be called when a new event occurs
+   * \param[in] event_type identifier for the qos event we want to attach the callback to
+   */
+  void
+  set_on_new_qos_event_callback(
+    std::function<void(size_t)> callback,
+    rcl_publisher_event_type_t event_type)
+  {
+    if (event_handlers_.count(event_type) == 0) {
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "Calling set_on_new_qos_event_callback for non registered event_type");
+      return;
+    }
+
+    if (!callback) {
+      throw std::invalid_argument(
+              "The callback passed to set_on_new_qos_event_callback "
+              "is not callable.");
+    }
+
+    // The on_ready_callback signature has an extra `int` argument used to disambiguate between
+    // possible different entities within a generic waitable.
+    // We hide that detail to users of this method.
+    std::function<void(size_t, int)> new_callback = std::bind(callback, std::placeholders::_1);
+    event_handlers_[event_type]->set_on_ready_callback(new_callback);
+  }
+
+  /// Unset the callback registered for new qos events, if any.
+  void
+  clear_on_new_qos_event_callback(rcl_publisher_event_type_t event_type)
+  {
+    if (event_handlers_.count(event_type) == 0) {
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "Calling clear_on_new_qos_event_callback for non registered event_type");
+      return;
+    }
+
+    event_handlers_[event_type]->clear_on_ready_callback();
+  }
+
 protected:
   template<typename EventCallbackT>
   void
@@ -206,7 +274,7 @@ protected:
       rcl_publisher_event_init,
       publisher_handle_,
       event_type);
-    event_handlers_.emplace_back(handler);
+    event_handlers_.insert(std::make_pair(event_type, handler));
   }
 
   RCLCPP_PUBLIC
@@ -216,7 +284,8 @@ protected:
 
   std::shared_ptr<rcl_publisher_t> publisher_handle_;
 
-  std::vector<std::shared_ptr<rclcpp::QOSEventHandlerBase>> event_handlers_;
+  std::unordered_map<rcl_publisher_event_type_t,
+    std::shared_ptr<rclcpp::QOSEventHandlerBase>> event_handlers_;
 
   using IntraProcessManagerWeakPtr =
     std::weak_ptr<rclcpp::experimental::IntraProcessManager>;

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -147,7 +147,6 @@ public:
    *
    * \param[in] callback functor to be called when a new event occurs
    */
-  RCLCPP_PUBLIC
   void
   set_on_ready_callback(std::function<void(size_t, int)> callback) override
   {
@@ -198,7 +197,6 @@ public:
   }
 
   /// Unset the callback registered for new events, if any.
-  RCLCPP_PUBLIC
   void
   clear_on_ready_callback() override
   {

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -17,6 +17,7 @@
 
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 
@@ -182,6 +183,8 @@ public:
         }
       };
 
+    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
+
     // Set it temporarily to the new callback, while we replace the old one.
     // This two-step setting, prevents a gap where the old std::function has
     // been replaced but the middleware hasn't been told about the new one yet.
@@ -203,6 +206,7 @@ public:
   void
   clear_on_ready_callback() override
   {
+    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
     set_on_new_event_callback(nullptr, nullptr);
     on_new_event_callback_ = nullptr;
   }
@@ -214,6 +218,7 @@ protected:
 
   rcl_event_t event_handle_;
   size_t wait_set_event_index_;
+  std::recursive_mutex reentrant_mutex_;
   std::function<void(size_t)> on_new_event_callback_{nullptr};
 };
 

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -113,9 +113,9 @@ public:
 
   /// Set a callback to be called when each new event instance occurs.
   /**
-   * The callback receives a size_t which is the number of responses received
+   * The callback receives a size_t which is the number of events that occurred
    * since the last time this callback was called.
-   * Normally this is 1, but can be > 1 if responses were received before any
+   * Normally this is 1, but can be > 1 if events occurred before any
    * callback was set.
    *
    * The callback also receives an int identifier argument.
@@ -124,7 +124,7 @@ public:
    * The application should provide a generic callback function that will be then
    * forwarded by the waitable to all of its entities.
    * Before forwarding, a different value for the identifier argument will be
-   * bounded to the function.
+   * bond to the function.
    * This implies that the provided callback can use the identifier to behave
    * differently depending on which entity triggered the waitable to become ready.
    *
@@ -139,13 +139,9 @@ public:
    *
    * This function is thread-safe.
    *
-   * If you want more information available in the callback, like the client
+   * If you want more information available in the callback, like the qos event
    * or other information, you may use a lambda with captures or std::bind.
    *
-   * Note: this function must be overridden with a proper implementation
-   * by the custom classes who inherit from rclcpp::Waitable if they want to use it.
-   *
-   * \sa rclcpp::QOSEventHandlerBase::clear_on_ready_callback
    * \sa rmw_event_set_callback
    * \sa rcl_event_set_callback
    *

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -19,6 +19,7 @@
 #include <functional>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <string>
 
@@ -183,6 +184,8 @@ public:
         }
       };
 
+    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
+
     // Set it temporarily to the new callback, while we replace the old one.
     // This two-step setting, prevents a gap where the old std::function has
     // been replaced but the middleware hasn't been told about the new one yet.
@@ -204,6 +207,7 @@ public:
   void
   clear_on_new_request_callback()
   {
+    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
     set_on_new_request_callback(nullptr, nullptr);
     on_new_request_callback_ = nullptr;
   }
@@ -232,6 +236,7 @@ protected:
 
   std::atomic<bool> in_use_by_wait_set_{false};
 
+  std::recursive_mutex reentrant_mutex_;
   std::function<void(size_t)> on_new_request_callback_{nullptr};
 };
 

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -148,13 +148,11 @@ public:
    * If you want more information available in the callback, like the service
    * or other information, you may use a lambda with captures or std::bind.
    *
-   * \sa rclcpp::ServiceBase::clear_on_new_request_callback
    * \sa rmw_service_set_on_new_request_callback
    * \sa rcl_service_set_on_new_request_callback
    *
    * \param[in] callback functor to be called when a new request is received
    */
-  RCLCPP_PUBLIC
   void
   set_on_new_request_callback(std::function<void(size_t)> callback)
   {
@@ -203,7 +201,6 @@ public:
   }
 
   /// Unset the callback registered for new requests, if any.
-  RCLCPP_PUBLIC
   void
   clear_on_new_request_callback()
   {

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -139,19 +139,30 @@ public:
    *
    * Calling it again will clear any previously set callback.
    *
+   *
+   * An exception will be thrown if the callback is not callable.
+   *
    * This function is thread-safe.
    *
    * If you want more information available in the callback, like the service
    * or other information, you may use a lambda with captures or std::bind.
    *
+   * \sa rclcpp::ServiceBase::clear_on_new_request_callback
    * \sa rmw_service_set_on_new_request_callback
    * \sa rcl_service_set_on_new_request_callback
    *
    * \param[in] callback functor to be called when a new request is received
    */
+  RCLCPP_PUBLIC
   void
   set_on_new_request_callback(std::function<void(size_t)> callback)
   {
+    if (!callback) {
+      throw std::invalid_argument(
+              "The callback passed to set_on_new_request_callback "
+              "is not callable.");
+    }
+
     auto new_callback =
       [callback, this](size_t number_of_requests) {
         try {
@@ -188,6 +199,15 @@ public:
       static_cast<const void *>(&on_new_request_callback_));
   }
 
+  /// Unset the callback registered for new requests, if any.
+  RCLCPP_PUBLIC
+  void
+  clear_on_new_request_callback()
+  {
+    set_on_new_request_callback(nullptr, nullptr);
+    on_new_request_callback_ = nullptr;
+  }
+
 protected:
   RCLCPP_DISABLE_COPY(ServiceBase)
 
@@ -212,7 +232,7 @@ protected:
 
   std::atomic<bool> in_use_by_wait_set_{false};
 
-  std::function<void(size_t)> on_new_request_callback_;
+  std::function<void(size_t)> on_new_request_callback_{nullptr};
 };
 
 template<typename ServiceT>

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -171,6 +171,10 @@ public:
 
       // First create a SubscriptionIntraProcess which will be given to the intra-process manager.
       auto context = node_base->get_context();
+      using SubscriptionIntraProcessT = rclcpp::experimental::SubscriptionIntraProcess<
+        CallbackMessageT,
+        AllocatorT,
+        typename MessageUniquePtr::deleter_type>;
       subscription_intra_process_ = std::make_shared<SubscriptionIntraProcessT>(
         callback,
         options.get_allocator(),

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -343,11 +343,6 @@ private:
     message_memory_strategy_;
   /// Component which computes and publishes topic statistics for this subscriber
   SubscriptionTopicStatisticsSharedPtr subscription_topic_statistics_{nullptr};
-  using SubscriptionIntraProcessT = rclcpp::experimental::SubscriptionIntraProcess<
-    CallbackMessageT,
-    AllocatorT,
-    typename MessageUniquePtr::deleter_type>;
-  std::shared_ptr<SubscriptionIntraProcessT> subscription_intra_process_;
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -17,6 +17,7 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -289,7 +290,6 @@ public:
    *
    * \param[in] callback functor to be called when a new message is received
    */
-  RCLCPP_PUBLIC
   void
   set_on_new_message_callback(std::function<void(size_t)> callback)
   {
@@ -319,6 +319,8 @@ public:
         }
       };
 
+    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
+
     // Set it temporarily to the new callback, while we replace the old one.
     // This two-step setting, prevents a gap where the old std::function has
     // been replaced but the middleware hasn't been told about the new one yet.
@@ -336,10 +338,10 @@ public:
   }
 
   /// Unset the callback registered for new messages, if any.
-  RCLCPP_PUBLIC
   void
   clear_on_new_message_callback()
   {
+    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
     set_on_new_message_callback(nullptr, nullptr);
     on_new_message_callback_ = nullptr;
   }
@@ -396,6 +398,7 @@ private:
   std::unordered_map<rclcpp::QOSEventHandlerBase *,
     std::atomic<bool>> qos_events_in_use_by_wait_set_;
 
+  std::recursive_mutex reentrant_mutex_;
   std::function<void(size_t)> on_new_message_callback_{nullptr};
 };
 

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -346,6 +346,55 @@ public:
     on_new_message_callback_ = nullptr;
   }
 
+  /// Set a callback to be called when each new intra-process message is received.
+  /**
+   * The callback receives a size_t which is the number of messages received
+   * since the last time this callback was called.
+   * Normally this is 1, but can be > 1 if messages were received before any
+   * callback was set.
+   *
+   * Calling it again will clear any previously set callback.
+   *
+   * This function is thread-safe.
+   *
+   * If you want more information available in the callback, like the subscription
+   * or other information, you may use a lambda with captures or std::bind.
+   *
+   * \sa rclcpp::SubscriptionIntraProcessBase::set_on_ready_callback
+   *
+   * \param[in] callback functor to be called when a new message is received
+   */
+  void
+  set_on_new_intra_process_message_callback(std::function<void(size_t)> callback)
+  {
+    if (!use_intra_process_) {
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "Calling set_on_new_intra_process_message_callback for subscription with IPC disabled");
+      return;
+    }
+
+    // The on_ready_callback signature has an extra `int` argument used to disambiguate between 
+    // possible different entities within a generic waitable.
+    // We hide that detail to users of this method.
+    std::function<void(size_t, int)> new_callback = std::bind(callback, std::placeholders::_1);
+    subscription_intra_process_->set_on_ready_callback(new_callback);
+  }
+
+  /// Unset the callback registered for new intra-process messages, if any.
+  void
+  clear_on_new_intra_process_message_callback()
+  {
+    if (!use_intra_process_) {
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "Calling clear_on_new_intra_process_message_callback for subscription with IPC disabled");
+      return;
+    }
+
+    subscription_intra_process_->clear_on_ready_callback();
+  }
+
 protected:
   template<typename EventCallbackT>
   void
@@ -386,6 +435,7 @@ protected:
   bool use_intra_process_;
   IntraProcessManagerWeakPtr weak_ipm_;
   uint64_t intra_process_subscription_id_;
+  std::shared_ptr<SubscriptionIntraProcessBase> subscription_intra_process_;
 
 private:
   RCLCPP_DISABLE_COPY(SubscriptionBase)

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -289,9 +289,16 @@ public:
    *
    * \param[in] callback functor to be called when a new message is received
    */
+  RCLCPP_PUBLIC
   void
   set_on_new_message_callback(std::function<void(size_t)> callback)
   {
+    if (!callback) {
+      throw std::invalid_argument(
+              "The callback passed to set_on_new_message_callback "
+              "is not callable.");
+    }
+
     auto new_callback =
       [callback, this](size_t number_of_messages) {
         try {
@@ -326,6 +333,15 @@ public:
     set_on_new_message_callback(
       rclcpp::detail::cpp_callback_trampoline<const void *, size_t>,
       static_cast<const void *>(&on_new_message_callback_));
+  }
+
+  /// Unset the callback registered for new messages, if any.
+  RCLCPP_PUBLIC
+  void
+  clear_on_new_message_callback()
+  {
+    set_on_new_message_callback(nullptr, nullptr);
+    on_new_message_callback_ = nullptr;
   }
 
 protected:
@@ -380,7 +396,7 @@ private:
   std::unordered_map<rclcpp::QOSEventHandlerBase *,
     std::atomic<bool>> qos_events_in_use_by_wait_set_;
 
-  std::function<void(size_t)> on_new_message_callback_;
+  std::function<void(size_t)> on_new_message_callback_{nullptr};
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -374,7 +374,13 @@ public:
       return;
     }
 
-    // The on_ready_callback signature has an extra `int` argument used to disambiguate between 
+    if (!callback) {
+      throw std::invalid_argument(
+              "The callback passed to set_on_new_intra_process_message_callback "
+              "is not callable.");
+    }
+
+    // The on_ready_callback signature has an extra `int` argument used to disambiguate between
     // possible different entities within a generic waitable.
     // We hide that detail to users of this method.
     std::function<void(size_t, int)> new_callback = std::bind(callback, std::placeholders::_1);
@@ -435,7 +441,7 @@ protected:
   bool use_intra_process_;
   IntraProcessManagerWeakPtr weak_ipm_;
   uint64_t intra_process_subscription_id_;
-  std::shared_ptr<SubscriptionIntraProcessBase> subscription_intra_process_;
+  std::shared_ptr<rclcpp::experimental::SubscriptionIntraProcessBase> subscription_intra_process_;
 
 private:
   RCLCPP_DISABLE_COPY(SubscriptionBase)

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -98,9 +98,10 @@ public:
   get_subscription_handle() const;
 
   /// Get all the QoS event handlers associated with this subscription.
-  /** \return The vector of QoS event handlers. */
+  /** \return The map of QoS event handlers. */
   RCLCPP_PUBLIC
-  const std::vector<std::shared_ptr<rclcpp::QOSEventHandlerBase>> &
+  const
+  std::unordered_map<rcl_subscription_event_type_t, std::shared_ptr<rclcpp::QOSEventHandlerBase>> &
   get_event_handlers() const;
 
   /// Get the actual QoS settings, after the defaults have been determined.
@@ -401,6 +402,71 @@ public:
     subscription_intra_process_->clear_on_ready_callback();
   }
 
+  /// Set a callback to be called when each new qos event instance occurs.
+  /**
+   * The callback receives a size_t which is the number of events that occurred
+   * since the last time this callback was called.
+   * Normally this is 1, but can be > 1 if events occurred before any
+   * callback was set.
+   *
+   * Since this callback is called from the middleware, you should aim to make
+   * it fast and not blocking.
+   * If you need to do a lot of work or wait for some other event, you should
+   * spin it off to another thread, otherwise you risk blocking the middleware.
+   *
+   * Calling it again will clear any previously set callback.
+   *
+   * An exception will be thrown if the callback is not callable.
+   *
+   * This function is thread-safe.
+   *
+   * If you want more information available in the callback, like the qos event
+   * or other information, you may use a lambda with captures or std::bind.
+   *
+   * \sa rclcpp::QOSEventHandlerBase::set_on_ready_callback
+   *
+   * \param[in] callback functor to be called when a new event occurs
+   * \param[in] event_type identifier for the qos event we want to attach the callback to
+   */
+  void
+  set_on_new_qos_event_callback(
+    std::function<void(size_t)> callback,
+    rcl_subscription_event_type_t event_type)
+  {
+    if (event_handlers_.count(event_type) == 0) {
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "Calling set_on_new_qos_event_callback for non registered event_type");
+      return;
+    }
+
+    if (!callback) {
+      throw std::invalid_argument(
+              "The callback passed to set_on_new_qos_event_callback "
+              "is not callable.");
+    }
+
+    // The on_ready_callback signature has an extra `int` argument used to disambiguate between
+    // possible different entities within a generic waitable.
+    // We hide that detail to users of this method.
+    std::function<void(size_t, int)> new_callback = std::bind(callback, std::placeholders::_1);
+    event_handlers_[event_type]->set_on_ready_callback(new_callback);
+  }
+
+  /// Unset the callback registered for new qos events, if any.
+  void
+  clear_on_new_qos_event_callback(rcl_subscription_event_type_t event_type)
+  {
+    if (event_handlers_.count(event_type) == 0) {
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "Calling clear_on_new_qos_event_callback for non registered event_type");
+      return;
+    }
+
+    event_handlers_[event_type]->clear_on_ready_callback();
+  }
+
 protected:
   template<typename EventCallbackT>
   void
@@ -415,7 +481,7 @@ protected:
       get_subscription_handle(),
       event_type);
     qos_events_in_use_by_wait_set_.insert(std::make_pair(handler.get(), false));
-    event_handlers_.emplace_back(handler);
+    event_handlers_.insert(std::make_pair(event_type, handler));
   }
 
   RCLCPP_PUBLIC
@@ -436,7 +502,8 @@ protected:
   std::shared_ptr<rcl_subscription_t> intra_process_subscription_handle_;
   rclcpp::Logger node_logger_;
 
-  std::vector<std::shared_ptr<rclcpp::QOSEventHandlerBase>> event_handlers_;
+  std::unordered_map<rcl_subscription_event_type_t,
+    std::shared_ptr<rclcpp::QOSEventHandlerBase>> event_handlers_;
 
   bool use_intra_process_;
   IntraProcessManagerWeakPtr weak_ipm_;

--- a/rclcpp/include/rclcpp/wait_set_template.hpp
+++ b/rclcpp/include/rclcpp/wait_set_template.hpp
@@ -155,7 +155,8 @@ public:
           this->storage_add_subscription(std::move(local_subscription));
         }
         if (mask.include_events) {
-          for (auto event : inner_subscription->get_event_handlers()) {
+          for (auto key_event_pair : inner_subscription->get_event_handlers()) {
+            auto event = key_event_pair.second;
             auto local_subscription = inner_subscription;
             bool already_in_use =
             local_subscription->exchange_in_use_by_wait_set_state(event.get(), true);
@@ -225,7 +226,8 @@ public:
           this->storage_remove_subscription(std::move(local_subscription));
         }
         if (mask.include_events) {
-          for (auto event : inner_subscription->get_event_handlers()) {
+          for (auto key_event_pair : inner_subscription->get_event_handlers()) {
+            auto event = key_event_pair.second;
             auto local_subscription = inner_subscription;
             local_subscription->exchange_in_use_by_wait_set_state(event.get(), false);
             this->storage_remove_waitable(std::move(event));

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -228,7 +228,6 @@ public:
    *
    * \param[in] callback functor to be called when the waitable becomes ready
    */
-  RCLCPP_PUBLIC
   virtual
   void
   set_on_ready_callback(std::function<void(size_t, int)> callback);
@@ -238,7 +237,6 @@ public:
    * Note: this function must be overridden with a proper implementation
    * by the custom classes who inherit from rclcpp::Waitable if they want to use it.
    */
-  RCLCPP_PUBLIC
   virtual
   void
   clear_on_ready_callback();

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -206,9 +206,9 @@ public:
 
   /// Set a callback to be called whenever the waitable becomes ready.
   /**
-   * The callback receives a size_t which is the number of responses received
+   * The callback receives a size_t which is the number of times the waitable was ready
    * since the last time this callback was called.
-   * Normally this is 1, but can be > 1 if responses were received before any
+   * Normally this is 1, but can be > 1 if waitable was triggered before any
    * callback was set.
    *
    * The callback also receives an int identifier argument.

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -217,7 +217,7 @@ public:
    * The application should provide a generic callback function that will be then
    * forwarded by the waitable to all of its entities.
    * Before forwarding, a different value for the identifier argument will be
-   * bounded to the function.
+   * bond to the function.
    * This implies that the provided callback can use the identifier to behave
    * differently depending on which entity triggered the waitable to become ready.
    *

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -16,6 +16,7 @@
 #define RCLCPP__WAITABLE_HPP_
 
 #include <atomic>
+#include <functional>
 #include <memory>
 
 #include "rclcpp/macros.hpp"
@@ -202,6 +203,45 @@ public:
   RCLCPP_PUBLIC
   bool
   exchange_in_use_by_wait_set_state(bool in_use_state);
+
+  /// Set a callback to be called whenever the waitable becomes ready.
+  /**
+   * The callback receives a size_t which is the number of responses received
+   * since the last time this callback was called.
+   * Normally this is 1, but can be > 1 if responses were received before any
+   * callback was set.
+   *
+   * The callback also receives an int identifier argument.
+   * This is needed because a Waitable may be composed of several distinct entities,
+   * such as subscriptions, services, etc.
+   * The application should provide a generic callback function that will be then
+   * forwarded by the waitable to all of its entities.
+   * Before forwarding, a different value for the identifier argument will be
+   * bounded to the function.
+   * This implies that the provided callback can use the identifier to behave
+   * differently depending on which entity triggered the waitable to become ready.
+   *
+   * Note: this function must be overridden with a proper implementation
+   * by the custom classes who inherit from rclcpp::Waitable if they want to use it.
+   *
+   * \sa rclcpp::Waitable::clear_on_ready_callback
+   *
+   * \param[in] callback functor to be called when the waitable becomes ready
+   */
+  RCLCPP_PUBLIC
+  virtual
+  void
+  set_on_ready_callback(std::function<void(size_t, int)> callback);
+
+  /// Unset any callback registered via set_on_ready_callback.
+  /**
+   * Note: this function must be overridden with a proper implementation
+   * by the custom classes who inherit from rclcpp::Waitable if they want to use it.
+   */
+  RCLCPP_PUBLIC
+  virtual
+  void
+  clear_on_ready_callback();
 
 private:
   std::atomic<bool> in_use_by_wait_set_{false};

--- a/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
@@ -55,7 +55,8 @@ NodeTopics::add_publisher(
     callback_group = node_base_->get_default_callback_group();
   }
 
-  for (auto & publisher_event : publisher->get_event_handlers()) {
+  for (auto & key_event_pair : publisher->get_event_handlers()) {
+    auto publisher_event = key_event_pair.second;
     callback_group->add_waitable(publisher_event);
   }
 
@@ -97,7 +98,8 @@ NodeTopics::add_subscription(
 
   callback_group->add_subscription(subscription);
 
-  for (auto & subscription_event : subscription->get_event_handlers()) {
+  for (auto & key_event_pair : subscription->get_event_handlers()) {
+    auto subscription_event = key_event_pair.second;
     callback_group->add_waitable(subscription_event);
   }
 

--- a/rclcpp/src/rclcpp/publisher_base.cpp
+++ b/rclcpp/src/rclcpp/publisher_base.cpp
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "rcutils/logging_macros.h"
@@ -153,7 +154,8 @@ PublisherBase::get_publisher_handle() const
   return publisher_handle_;
 }
 
-const std::vector<std::shared_ptr<rclcpp::QOSEventHandlerBase>> &
+const
+std::unordered_map<rcl_publisher_event_type_t, std::shared_ptr<rclcpp::QOSEventHandlerBase>> &
 PublisherBase::get_event_handlers() const
 {
   return event_handlers_;

--- a/rclcpp/src/rclcpp/subscription_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_base.cpp
@@ -17,6 +17,7 @@
 #include <cstdio>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "rclcpp/exceptions.hpp"
@@ -116,7 +117,8 @@ SubscriptionBase::get_subscription_handle() const
   return subscription_handle_;
 }
 
-const std::vector<std::shared_ptr<rclcpp::QOSEventHandlerBase>> &
+const
+std::unordered_map<rcl_subscription_event_type_t, std::shared_ptr<rclcpp::QOSEventHandlerBase>> &
 SubscriptionBase::get_event_handlers() const
 {
   return event_handlers_;
@@ -282,7 +284,8 @@ SubscriptionBase::exchange_in_use_by_wait_set_state(
   if (get_intra_process_waitable().get() == pointer_to_subscription_part) {
     return intra_process_subscription_waitable_in_use_by_wait_set_.exchange(in_use_state);
   }
-  for (const auto & qos_event : event_handlers_) {
+  for (const auto & key_event_pair : event_handlers_) {
+    auto qos_event = key_event_pair.second;
     if (qos_event.get() == pointer_to_subscription_part) {
       return qos_events_in_use_by_wait_set_[qos_event.get()].exchange(in_use_state);
     }

--- a/rclcpp/src/rclcpp/waitable.cpp
+++ b/rclcpp/src/rclcpp/waitable.cpp
@@ -59,3 +59,21 @@ Waitable::exchange_in_use_by_wait_set_state(bool in_use_state)
 {
   return in_use_by_wait_set_.exchange(in_use_state);
 }
+
+void
+Waitable::set_on_ready_callback(std::function<void(size_t, int)> callback)
+{
+  (void)callback;
+
+  throw std::runtime_error(
+          "Custom waitables should override set_on_ready_callback "
+          "if they want to use it.");
+}
+
+void
+Waitable::clear_on_ready_callback()
+{
+  throw std::runtime_error(
+          "Custom waitables should override clear_on_ready_callback "
+          "if they want to use it.");
+}

--- a/rclcpp/test/rclcpp/test_client.cpp
+++ b/rclcpp/test/rclcpp/test_client.cpp
@@ -27,6 +27,8 @@
 
 #include "test_msgs/srv/empty.hpp"
 
+using namespace std::chrono_literals;
+
 class TestClient : public ::testing::Test
 {
 protected:
@@ -327,4 +329,93 @@ TEST_F(TestClientWithServer, take_response) {
       client->take_response(response, *request_header.get()),
       rclcpp::exceptions::RCLError);
   }
+}
+
+/*
+   Testing on_new_response callbacks.
+ */
+TEST_F(TestClient, on_new_response_callback) {
+  auto client_node = std::make_shared<rclcpp::Node>("client_node", "ns");
+  auto server_node = std::make_shared<rclcpp::Node>("server_node", "ns");
+
+  auto client = client_node->create_client<test_msgs::srv::Empty>("test_service");
+  std::atomic<size_t> server_requests_count {0};
+  auto server_callback = [&server_requests_count](
+    const test_msgs::srv::Empty::Request::SharedPtr,
+    test_msgs::srv::Empty::Response::SharedPtr) {server_requests_count++;};
+  auto server = server_node->create_service<test_msgs::srv::Empty>("test_service", server_callback);
+  auto request = std::make_shared<test_msgs::srv::Empty::Request>();
+
+  std::atomic<size_t> c1 {0};
+  auto increase_c1_cb = [&c1](size_t count_msgs) {c1 += count_msgs;};
+  client->set_on_new_response_callback(increase_c1_cb);
+
+  client->async_send_request(request);
+  auto start = std::chrono::steady_clock::now();
+  while (server_requests_count == 0 &&
+    (std::chrono::steady_clock::now() - start) < 10s)
+  {
+    rclcpp::spin_some(server_node);
+  }
+
+  ASSERT_EQ(server_requests_count, 1u);
+
+  start = std::chrono::steady_clock::now();
+  do {
+    std::this_thread::sleep_for(100ms);
+  } while (c1 == 0 && std::chrono::steady_clock::now() - start < 10s);
+
+  EXPECT_EQ(c1.load(), 1u);
+
+  std::atomic<size_t> c2 {0};
+  auto increase_c2_cb = [&c2](size_t count_msgs) {c2 += count_msgs;};
+  client->set_on_new_response_callback(increase_c2_cb);
+
+  client->async_send_request(request);
+  start = std::chrono::steady_clock::now();
+  while (server_requests_count == 1 &&
+    (std::chrono::steady_clock::now() - start) < 10s)
+  {
+    rclcpp::spin_some(server_node);
+  }
+
+  ASSERT_EQ(server_requests_count, 2u);
+
+  start = std::chrono::steady_clock::now();
+  do {
+    std::this_thread::sleep_for(100ms);
+  } while (c1 == 0 && std::chrono::steady_clock::now() - start < 10s);
+
+  EXPECT_EQ(c1.load(), 1u);
+  EXPECT_EQ(c2.load(), 1u);
+
+  client->clear_on_new_response_callback();
+
+  client->async_send_request(request);
+  client->async_send_request(request);
+  client->async_send_request(request);
+  start = std::chrono::steady_clock::now();
+  while (server_requests_count < 5 &&
+    (std::chrono::steady_clock::now() - start) < 10s)
+  {
+    rclcpp::spin_some(server_node);
+  }
+
+  ASSERT_EQ(server_requests_count, 5u);
+
+  std::atomic<size_t> c3 {0};
+  auto increase_c3_cb = [&c3](size_t count_msgs) {c3 += count_msgs;};
+  client->set_on_new_response_callback(increase_c3_cb);
+
+  start = std::chrono::steady_clock::now();
+  do {
+    std::this_thread::sleep_for(100ms);
+  } while (c3 == 0 && std::chrono::steady_clock::now() - start < 10s);
+
+  EXPECT_EQ(c1.load(), 1u);
+  EXPECT_EQ(c2.load(), 1u);
+  EXPECT_EQ(c3.load(), 3u);
+
+  std::function<void(size_t)> invalid_cb = nullptr;
+  EXPECT_THROW(client->set_on_new_response_callback(invalid_cb), std::invalid_argument);
 }

--- a/rclcpp/test/rclcpp/test_publisher.cpp
+++ b/rclcpp/test/rclcpp/test_publisher.cpp
@@ -501,7 +501,8 @@ TEST_F(TestPublisher, run_event_handlers) {
   initialize();
   auto publisher = node->create_publisher<test_msgs::msg::Empty>("topic", 10);
 
-  for (const auto & handler : publisher->get_event_handlers()) {
+  for (const auto & key_event_pair : publisher->get_event_handlers()) {
+    auto handler = key_event_pair.second;
     std::shared_ptr<void> data = handler->take_data();
     handler->execute(data);
   }

--- a/rclcpp/test/rclcpp/test_qos_event.cpp
+++ b/rclcpp/test/rclcpp/test_qos_event.cpp
@@ -391,3 +391,31 @@ TEST_F(TestQosEvent, test_on_new_event_callback)
   EXPECT_EQ(c1, 2u);
   EXPECT_EQ(c2, 2u);
 }
+
+TEST_F(TestQosEvent, test_invalid_on_new_event_callback)
+{
+  auto pub = node->create_publisher<test_msgs::msg::Empty>(topic_name, 10);
+  auto sub = node->create_subscription<test_msgs::msg::Empty>(topic_name, 10, message_callback);
+  auto dummy_cb = [](size_t count_events) {(void)count_events;};
+  std::function<void(size_t)> invalid_cb;
+
+  EXPECT_NO_THROW(
+    pub->set_on_new_qos_event_callback(dummy_cb, RCL_PUBLISHER_OFFERED_INCOMPATIBLE_QOS));
+
+  EXPECT_NO_THROW(
+    pub->clear_on_new_qos_event_callback(RCL_PUBLISHER_OFFERED_INCOMPATIBLE_QOS));
+
+  EXPECT_NO_THROW(
+    sub->set_on_new_qos_event_callback(dummy_cb, RCL_SUBSCRIPTION_REQUESTED_INCOMPATIBLE_QOS));
+
+  EXPECT_NO_THROW(
+    sub->clear_on_new_qos_event_callback(RCL_SUBSCRIPTION_REQUESTED_INCOMPATIBLE_QOS));
+
+  EXPECT_THROW(
+    pub->set_on_new_qos_event_callback(invalid_cb, RCL_PUBLISHER_OFFERED_INCOMPATIBLE_QOS),
+    std::invalid_argument);
+
+  EXPECT_THROW(
+    sub->set_on_new_qos_event_callback(invalid_cb, RCL_SUBSCRIPTION_REQUESTED_INCOMPATIBLE_QOS),
+    std::invalid_argument);
+}

--- a/rclcpp/test/rclcpp/test_subscription.cpp
+++ b/rclcpp/test/rclcpp/test_subscription.cpp
@@ -448,7 +448,7 @@ TEST_F(TestSubscription, on_new_message_callback) {
   using test_msgs::msg::Empty;
 
   auto do_nothing = [](std::shared_ptr<const test_msgs::msg::Empty>) {FAIL();};
-  auto sub = node->create_subscription<test_msgs::msg::Empty>("~/test_take", 1, do_nothing);
+  auto sub = node->create_subscription<test_msgs::msg::Empty>("~/test_take", 10, do_nothing);
 
   std::atomic<size_t> c1 {0};
   auto increase_c1_cb = [&c1](size_t count_msgs) {c1 += count_msgs;};
@@ -518,7 +518,7 @@ TEST_F(TestSubscription, on_new_intra_process_message_callback) {
   using test_msgs::msg::Empty;
 
   auto do_nothing = [](std::shared_ptr<const test_msgs::msg::Empty>) {FAIL();};
-  auto sub = node->create_subscription<test_msgs::msg::Empty>("~/test_take", 1, do_nothing);
+  auto sub = node->create_subscription<test_msgs::msg::Empty>("~/test_take", 10, do_nothing);
 
   std::atomic<size_t> c1 {0};
   auto increase_c1_cb = [&c1](size_t count_msgs) {c1 += count_msgs;};

--- a/rclcpp/test/rclcpp/test_subscription.cpp
+++ b/rclcpp/test/rclcpp/test_subscription.cpp
@@ -444,7 +444,7 @@ TEST_F(TestSubscription, handle_loaned_message) {
    Testing on_new_message callbacks.
  */
 TEST_F(TestSubscription, on_new_message_callback) {
-  initialize();
+  initialize(rclcpp::NodeOptions().use_intra_process_comms(false));
   using test_msgs::msg::Empty;
 
   auto do_nothing = [](std::shared_ptr<const test_msgs::msg::Empty>) {FAIL();};
@@ -508,6 +508,76 @@ TEST_F(TestSubscription, on_new_message_callback) {
 
   std::function<void(size_t)> invalid_cb = nullptr;
   EXPECT_THROW(sub->set_on_new_message_callback(invalid_cb), std::invalid_argument);
+}
+
+/*
+   Testing on_new_intra_process_message callbacks.
+ */
+TEST_F(TestSubscription, on_new_intra_process_message_callback) {
+  initialize(rclcpp::NodeOptions().use_intra_process_comms(true));
+  using test_msgs::msg::Empty;
+
+  auto do_nothing = [](std::shared_ptr<const test_msgs::msg::Empty>) {FAIL();};
+  auto sub = node->create_subscription<test_msgs::msg::Empty>("~/test_take", 1, do_nothing);
+
+  std::atomic<size_t> c1 {0};
+  auto increase_c1_cb = [&c1](size_t count_msgs) {c1 += count_msgs;};
+  sub->set_on_new_intra_process_message_callback(increase_c1_cb);
+
+  auto pub = node->create_publisher<test_msgs::msg::Empty>("~/test_take", 1);
+  {
+    test_msgs::msg::Empty msg;
+    pub->publish(msg);
+  }
+
+  auto start = std::chrono::steady_clock::now();
+  do {
+    std::this_thread::sleep_for(100ms);
+  } while (c1 == 0 && std::chrono::steady_clock::now() - start < 10s);
+
+  EXPECT_EQ(c1.load(), 1u);
+
+  std::atomic<size_t> c2 {0};
+  auto increase_c2_cb = [&c2](size_t count_msgs) {c2 += count_msgs;};
+  sub->set_on_new_intra_process_message_callback(increase_c2_cb);
+
+  {
+    test_msgs::msg::Empty msg;
+    pub->publish(msg);
+  }
+
+  start = std::chrono::steady_clock::now();
+  do {
+    std::this_thread::sleep_for(100ms);
+  } while (c2 == 0 && std::chrono::steady_clock::now() - start < 10s);
+
+  EXPECT_EQ(c1.load(), 1u);
+  EXPECT_EQ(c2.load(), 1u);
+
+  sub->clear_on_new_intra_process_message_callback();
+
+  {
+    test_msgs::msg::Empty msg;
+    pub->publish(msg);
+    pub->publish(msg);
+    pub->publish(msg);
+  }
+
+  std::atomic<size_t> c3 {0};
+  auto increase_c3_cb = [&c3](size_t count_msgs) {c3 += count_msgs;};
+  sub->set_on_new_intra_process_message_callback(increase_c3_cb);
+
+  start = std::chrono::steady_clock::now();
+  do {
+    std::this_thread::sleep_for(100ms);
+  } while (c3 == 0 && std::chrono::steady_clock::now() - start < 10s);
+
+  EXPECT_EQ(c1.load(), 1u);
+  EXPECT_EQ(c2.load(), 1u);
+  EXPECT_EQ(c3.load(), 3u);
+
+  std::function<void(size_t)> invalid_cb = nullptr;
+  EXPECT_THROW(sub->set_on_new_intra_process_message_callback(invalid_cb), std::invalid_argument);
 }
 
 /*

--- a/rclcpp/test/rclcpp/test_subscription.cpp
+++ b/rclcpp/test/rclcpp/test_subscription.cpp
@@ -441,6 +441,76 @@ TEST_F(TestSubscription, handle_loaned_message) {
 }
 
 /*
+   Testing on_new_message callbacks.
+ */
+TEST_F(TestSubscription, on_new_message_callback) {
+  initialize();
+  using test_msgs::msg::Empty;
+
+  auto do_nothing = [](std::shared_ptr<const test_msgs::msg::Empty>) {FAIL();};
+  auto sub = node->create_subscription<test_msgs::msg::Empty>("~/test_take", 1, do_nothing);
+
+  std::atomic<size_t> c1 {0};
+  auto increase_c1_cb = [&c1](size_t count_msgs) {c1 += count_msgs;};
+  sub->set_on_new_message_callback(increase_c1_cb);
+
+  auto pub = node->create_publisher<test_msgs::msg::Empty>("~/test_take", 1);
+  {
+    test_msgs::msg::Empty msg;
+    pub->publish(msg);
+  }
+
+  auto start = std::chrono::steady_clock::now();
+  do {
+    std::this_thread::sleep_for(100ms);
+  } while (c1 == 0 && std::chrono::steady_clock::now() - start < 10s);
+
+  EXPECT_EQ(c1.load(), 1u);
+
+  std::atomic<size_t> c2 {0};
+  auto increase_c2_cb = [&c2](size_t count_msgs) {c2 += count_msgs;};
+  sub->set_on_new_message_callback(increase_c2_cb);
+
+  {
+    test_msgs::msg::Empty msg;
+    pub->publish(msg);
+  }
+
+  start = std::chrono::steady_clock::now();
+  do {
+    std::this_thread::sleep_for(100ms);
+  } while (c2 == 0 && std::chrono::steady_clock::now() - start < 10s);
+
+  EXPECT_EQ(c1.load(), 1u);
+  EXPECT_EQ(c2.load(), 1u);
+
+  sub->clear_on_new_message_callback();
+
+  {
+    test_msgs::msg::Empty msg;
+    pub->publish(msg);
+    pub->publish(msg);
+    pub->publish(msg);
+  }
+
+  std::atomic<size_t> c3 {0};
+  auto increase_c3_cb = [&c3](size_t count_msgs) {c3 += count_msgs;};
+  sub->set_on_new_message_callback(increase_c3_cb);
+
+  start = std::chrono::steady_clock::now();
+  do {
+    std::this_thread::sleep_for(100ms);
+  } while (c3 == 0 && std::chrono::steady_clock::now() - start < 10s);
+
+  EXPECT_EQ(c1.load(), 1u);
+  EXPECT_EQ(c2.load(), 1u);
+  EXPECT_EQ(c3.load(), 3u);
+
+  std::function<void(size_t)> invalid_cb = nullptr;
+  EXPECT_THROW(sub->set_on_new_message_callback(invalid_cb), std::invalid_argument);
+}
+
+/*
    Testing subscription with intraprocess enabled and invalid QoS
  */
 TEST_P(TestSubscriptionInvalidIntraprocessQos, test_subscription_throws) {

--- a/rclcpp/test/rclcpp/test_wait_set.cpp
+++ b/rclcpp/test/rclcpp/test_wait_set.cpp
@@ -257,7 +257,7 @@ TEST_F(TestWaitSet, add_guard_condition_to_two_different_wait_set) {
     rclcpp::PublisherOptions po;
     po.event_callbacks.deadline_callback = [](rclcpp::QOSDeadlineOfferedInfo &) {};
     auto pub = node->create_publisher<test_msgs::msg::BasicTypes>("~/test", 1, po);
-    auto qos_event = pub->get_event_handlers()[0];
+    auto qos_event = pub->get_event_handlers().begin()->second;
     wait_set1.add_waitable(qos_event, pub);
     ASSERT_THROW(
     {
@@ -301,7 +301,7 @@ TEST_F(TestWaitSet, add_remove_wait) {
     [](rclcpp::QOSDeadlineOfferedInfo &) {};
   auto pub = node->create_publisher<test_msgs::msg::BasicTypes>(
     "~/test", 1, publisher_options);
-  auto qos_event = pub->get_event_handlers()[0];
+  auto qos_event = pub->get_event_handlers().begin()->second;
 
   // Subscription mask is required here for coverage.
   wait_set.add_subscription(sub, {true, true, true});


### PR DESCRIPTION
Add on_ready callback to waitables
Add clear_* functions to remove callbacks from entities
Add unit-tests

Note: I haven't added unit-tests for qos-events (because they are broken until cyclonedds gets fixed) and for intra-process subscription (apparently there are no unit-tests for that at all)

This PR depends on https://github.com/irobot-ros/rcl/pull/20 where I allowed again to pass a nullptr callback (to unset existing one)

@mauropasse @pcouvignou-irobot