### PR TITLE
Use QoS depth to limit callbacks count

### DIFF
--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -142,8 +142,12 @@ public:
     on_new_message_callback_ = new_callback;
 
     if (unread_count_ > 0) {
-      // Use qos profile depth as upper bound for unread_count_
-      on_new_message_callback_(std::min(unread_count_, qos_profile_.depth));
+      if (qos_profile_.history == RMW_QOS_POLICY_HISTORY_KEEP_ALL || qos_profile_.depth == 0) {
+        on_new_message_callback_(unread_count_);
+      } else {
+        // Use qos profile depth as upper bound for unread_count_
+        on_new_message_callback_(std::min(unread_count_, qos_profile_.depth));
+      }
       unread_count_ = 0;
     }
   }


### PR DESCRIPTION
Signed-off-by: Mauro Passerino <mpasserino@irobot.com>