### PR TITLE
Bug fix: remove and add again node to executor

### DIFF
--- a/rclcpp/src/rclcpp/executors/events_executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/events_executor_entities_collector.cpp
@@ -359,6 +359,10 @@ EventsExecutorEntitiesCollector::remove_callback_group_from_map(
   // For all the entities in the group, unset their callbacks
   unset_callback_group_entities_callbacks(group_ptr);
 
+  // Mark this callback group as not associated with an executor anymore
+  std::atomic_bool & has_executor = group_ptr->get_associated_with_executor_atomic();
+  has_executor.store(false);
+
   // Check if this node still has other callback groups associated with the executor
   bool node_has_associated_callback_groups =
     has_node(node_ptr, weak_groups_associated_with_executor_to_nodes_) ||


### PR DESCRIPTION
set has_executor bool of callback groups to false when removing from events executor

See minimal working example:
without the fix the node is not added again to the executor in the second loop, so the timer does not publish.

```
#include <chrono>
#include <rclcpp/rclcpp.hpp>

using namespace std::chrono_literals;

int main(int argc, char **argv)
{
    rclcpp::init(argc, argv);

    auto node = std::make_shared<rclcpp::Node>("my_node");
    size_t count = 0;
    auto timer = node->create_wall_timer(50ms, [&count](){
        std::cout<<"timer"<<std::endl;
        count++;
    });

    auto executor = std::make_shared<rclcpp::executors::EventsExecutor>();
    executor->add_node(node);

    auto start = std::chrono::system_clock::now();
    while (std::chrono::system_clock::now() - start < 250ms) {
        executor->spin_some();
        std::this_thread::sleep_for(10ms);
    }
    std::cout<<"COUNT ---> "<<count<<std::endl;

    executor->remove_node(node);
    executor->add_node(node);

    start = std::chrono::system_clock::now();
    while (std::chrono::system_clock::now() - start < 250ms) {
        executor->spin_some();
        std::this_thread::sleep_for(10ms);
    }
    std::cout<<"COUNT ---> "<<count<<std::endl;

    rclcpp::shutdown();
}
```
