### PR TITLE
Callbacks seg fault: Specifically specify callback signature

### DIFF
--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -534,6 +534,18 @@ public:
 
   virtual ~Client()
   {
+    if (!use_intra_process_) {
+      return;
+    }
+    auto ipm = weak_ipm_.lock();
+    if (!ipm) {
+      // TODO(ivanpauno): should this raise an error?
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "Intra process manager died before than a client.");
+      return;
+    }
+    ipm->remove_client(intra_process_client_id_);
   }
 
   /// Take the next response for this client.

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -301,7 +301,7 @@ public:
               "is not callable.");
     }
 
-    auto new_callback =
+    std::function<void(size_t)> new_callback =
       [callback, this](size_t number_of_responses) {
         try {
           callback(number_of_responses);

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -367,9 +367,9 @@ public:
     if (service_it == services_.end()) {
       auto cli = get_client_intra_process(intra_process_client_id);
       auto warning_msg =
-       "There are no services to receive the intra-process request. "
-       "Do Inter process.\n"
-       "Client topic name: " + std::string(cli->get_service_name());
+        "Intra-process service gone out of scope. "
+        "Do inter-process requests.\n"
+        "Client service name: " + std::string(cli->get_service_name());
       RCLCPP_WARN(rclcpp::get_logger("rclcpp"), warning_msg.c_str());
       return;
     }

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -365,9 +365,13 @@ public:
 
     auto service_it = services_.find(service_id);
     if (service_it == services_.end()) {
-      throw std::runtime_error(
-              "There are no services to receive the intra-process request. "
-              "Do Inter process.");
+      auto cli = get_client_intra_process(intra_process_client_id);
+      auto warning_msg =
+       "There are no services to receive the intra-process request. "
+       "Do Inter process.\n"
+       "Client topic name: " + std::string(cli->get_service_name());
+      RCLCPP_WARN(rclcpp::get_logger("rclcpp"), warning_msg.c_str());
+      return;
     }
     auto service_intra_process_base = service_it->second.lock();
     if (service_intra_process_base) {

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -158,7 +158,7 @@ public:
     }
 
     // Note: we bind the int identifier argument to this waitable's entity types
-    auto new_callback =
+    std::function<void(size_t)> new_callback =
       [callback, this](size_t number_of_events) {
         try {
           callback(number_of_events, static_cast<int>(EntityType::Event));

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -481,6 +481,18 @@ public:
 
   virtual ~Service()
   {
+    if (!use_intra_process_) {
+      return;
+    }
+    auto ipm = weak_ipm_.lock();
+    if (!ipm) {
+      // TODO(ivanpauno): should this raise an error?
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "Intra process manager died before than a service.");
+      return;
+    }
+    ipm->remove_service(intra_process_service_id_);
   }
 
   /// Take the next request from the service.

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -215,7 +215,7 @@ public:
               "is not callable.");
     }
 
-    auto new_callback =
+    std::function<void(size_t)> new_callback =
       [callback, this](size_t number_of_requests) {
         try {
           callback(number_of_requests);

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -322,7 +322,7 @@ public:
               "is not callable.");
     }
 
-    auto new_callback =
+    std::function<void(size_t)> new_callback =
       [callback, this](size_t number_of_messages) {
         try {
           callback(number_of_messages);

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -93,7 +93,7 @@ public:
   {
     {
       std::lock_guard<std::mutex> clock_guard(clock->get_clock_mutex());
-      if (clock->get_clock_type() != RCL_ROS_TIME && ros_time_active_ == true) {
+      if (clock->get_clock_type() != RCL_ROS_TIME && ros_time_active_) {
         throw std::invalid_argument(
                 "ros_time_active_ can't be true while clock is not of RCL_ROS_TIME type");
       }
@@ -309,7 +309,7 @@ public:
     // can't possibly call any of the callbacks as we are cleaning up.
     destroy_clock_sub();
     clocks_state_.disable_ros_time();
-    if (on_set_parameters_callback_ && node_parameters_) {
+    if (on_set_parameters_callback_) {
       node_parameters_->remove_on_set_parameters_callback(on_set_parameters_callback_.get());
     }
     on_set_parameters_callback_.reset();

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -148,7 +148,7 @@ TimerBase::set_on_reset_callback(std::function<void(size_t)> callback)
             "is not callable.");
   }
 
-  auto new_callback =
+  std::function<void(size_t)> new_callback =
     [callback, this](size_t reset_calls) {
       try {
         callback(reset_calls);

--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -668,6 +668,19 @@ public:
       }
       it = goal_handles_.erase(it);
     }
+
+    if (!use_intra_process_) {
+      return;
+    }
+    auto ipm = weak_ipm_.lock();
+    if (!ipm) {
+      // TODO(ivanpauno): should this raise an error?
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "Intra process manager died before than an action client.");
+      return;
+    }
+    ipm->remove_action_client(ipc_action_client_id_);
   }
 
 private:

--- a/rclcpp_action/include/rclcpp_action/server.hpp
+++ b/rclcpp_action/include/rclcpp_action/server.hpp
@@ -478,7 +478,21 @@ public:
     }
   }
 
-  virtual ~Server() = default;
+  virtual ~Server()
+  {
+    if (!use_intra_process_) {
+      return;
+    }
+    auto ipm = weak_ipm_.lock();
+    if (!ipm) {
+      // TODO(ivanpauno): should this raise an error?
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "Intra process manager died before than an action server.");
+      return;
+    }
+    ipm->remove_action_server(ipc_action_server_id_);
+  }
 
 protected:
   // Intra-process version of execute_goal_request_received_

--- a/rclcpp_action/src/client.cpp
+++ b/rclcpp_action/src/client.cpp
@@ -407,7 +407,7 @@ ClientBase::set_callback_to_entity(
   std::function<void(size_t, int)> callback)
 {
   // Note: we bind the int identifier argument to this waitable's entity types
-  auto new_callback =
+  std::function<void(size_t)> new_callback =
     [callback, entity_type, this](size_t number_of_events) {
       try {
         callback(number_of_events, static_cast<int>(entity_type));

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -759,7 +759,7 @@ ServerBase::set_callback_to_entity(
   std::function<void(size_t, int)> callback)
 {
   // Note: we bind the int identifier argument to this waitable's entity types
-  auto new_callback =
+  std::function<void(size_t)> new_callback =
     [callback, entity_type, this](size_t number_of_events) {
       try {
         callback(number_of_events, static_cast<int>(entity_type));


### PR DESCRIPTION
This comes after experimenting with this example, where I get a pretty similar backtrace of the failure

```
#include <functional>
#include <iostream>
#include <type_traits>

template<
  typename UserDataT,
  typename ... Args,
  typename ReturnT = void
>
ReturnT
cpp_callback_trampoline(UserDataT user_data, Args ... args) noexcept
{
  auto & actual_callback = *reinterpret_cast<const std::function<ReturnT(Args...)> *>(user_data);
  std::cout << "Calling cpp_callback_trampoline actual_callback" << std::endl;
  return actual_callback(args ...);
}

int main() {
    std::function<void(size_t)> callback = [](size_t arg){
        std::cout << "f=" << arg << std::endl;
    };

    std::function<void(size_t)> new_callback =
        [callback](size_t arg) {
          callback(arg);
        };

    const void * user_data = static_cast<const void *>(&new_callback);

    void (*reinterpreted_callback)(const void *, size_t) = cpp_callback_trampoline<const void *, size_t>;

    // This works
    reinterpreted_callback(user_data, 10);

    // Now the same but with auto
    auto auto_callback = [](size_t arg)  {
        std::cout << "f=" << arg << std::endl;
    };

    // Types differ!
    if (std::is_same_v<decltype(callback), decltype(auto_callback)>) {
        std::cout << "callback and auto_callback have same type" << std::endl;
    } else {
        std::cout << "callback and auto_callback types differ!" << std::endl;
    }

    auto new_callback_auto =
        [auto_callback](size_t arg) {
          auto_callback(arg);
        };

    const void * user_data_auto = static_cast<const void *>(&new_callback_auto);
    // This fails
    reinterpreted_callback(user_data_auto, 10);
    return 0;
}
```