### PR TITLE
wait_for_service also looks for intra-process srvs

### DIFF
--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -534,6 +534,18 @@ public:
 
   virtual ~Client()
   {
+    if (!use_intra_process_) {
+      return;
+    }
+    auto ipm = weak_ipm_.lock();
+    if (!ipm) {
+      // TODO(ivanpauno): should this raise an error?
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "Intra process manager died before than a client.");
+      return;
+    }
+    ipm->remove_client(intra_process_client_id_);
   }
 
   /// Take the next response for this client.

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -358,6 +358,10 @@ protected:
   wait_for_service_nanoseconds(std::chrono::nanoseconds timeout);
 
   RCLCPP_PUBLIC
+  bool
+  wait_for_intra_process_service_nanoseconds(std::chrono::nanoseconds timeout);
+
+  RCLCPP_PUBLIC
   rcl_node_t *
   get_rcl_node_handle();
 

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -367,9 +367,9 @@ public:
     if (service_it == services_.end()) {
       auto cli = get_client_intra_process(intra_process_client_id);
       auto warning_msg =
-       "There are no services to receive the intra-process request. "
-       "Do Inter process.\n"
-       "Client topic name: " + std::string(cli->get_service_name());
+        "Intra-process service gone out of scope. "
+        "Do inter-process requests.\n"
+        "Client service name: " + std::string(cli->get_service_name());
       RCLCPP_WARN(rclcpp::get_logger("rclcpp"), warning_msg.c_str());
       return;
     }

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -365,9 +365,13 @@ public:
 
     auto service_it = services_.find(service_id);
     if (service_it == services_.end()) {
-      throw std::runtime_error(
-              "There are no services to receive the intra-process request. "
-              "Do Inter process.");
+      auto cli = get_client_intra_process(intra_process_client_id);
+      auto warning_msg =
+       "There are no services to receive the intra-process request. "
+       "Do Inter process.\n"
+       "Client topic name: " + std::string(cli->get_service_name());
+      RCLCPP_WARN(rclcpp::get_logger("rclcpp"), warning_msg.c_str());
+      return;
     }
     auto service_intra_process_base = service_it->second.lock();
     if (service_intra_process_base) {

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -481,6 +481,18 @@ public:
 
   virtual ~Service()
   {
+    if (!use_intra_process_) {
+      return;
+    }
+    auto ipm = weak_ipm_.lock();
+    if (!ipm) {
+      // TODO(ivanpauno): should this raise an error?
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "Intra process manager died before than a service.");
+      return;
+    }
+    ipm->remove_service(intra_process_service_id_);
   }
 
   /// Take the next request from the service.

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -93,7 +93,7 @@ public:
   {
     {
       std::lock_guard<std::mutex> clock_guard(clock->get_clock_mutex());
-      if (clock->get_clock_type() != RCL_ROS_TIME && ros_time_active_ == true) {
+      if (clock->get_clock_type() != RCL_ROS_TIME && ros_time_active_) {
         throw std::invalid_argument(
                 "ros_time_active_ can't be true while clock is not of RCL_ROS_TIME type");
       }
@@ -309,7 +309,7 @@ public:
     // can't possibly call any of the callbacks as we are cleaning up.
     destroy_clock_sub();
     clocks_state_.disable_ros_time();
-    if (on_set_parameters_callback_ && node_parameters_) {
+    if (on_set_parameters_callback_) {
       node_parameters_->remove_on_set_parameters_callback(on_set_parameters_callback_.get());
     }
     on_set_parameters_callback_.reset();

--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -668,6 +668,19 @@ public:
       }
       it = goal_handles_.erase(it);
     }
+
+    if (!use_intra_process_) {
+      return;
+    }
+    auto ipm = weak_ipm_.lock();
+    if (!ipm) {
+      // TODO(ivanpauno): should this raise an error?
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "Intra process manager died before than an action client.");
+      return;
+    }
+    ipm->remove_action_client(ipc_action_client_id_);
   }
 
 private:

--- a/rclcpp_action/include/rclcpp_action/server.hpp
+++ b/rclcpp_action/include/rclcpp_action/server.hpp
@@ -478,7 +478,21 @@ public:
     }
   }
 
-  virtual ~Server() = default;
+  virtual ~Server()
+  {
+    if (!use_intra_process_) {
+      return;
+    }
+    auto ipm = weak_ipm_.lock();
+    if (!ipm) {
+      // TODO(ivanpauno): should this raise an error?
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "Intra process manager died before than an action server.");
+      return;
+    }
+    ipm->remove_action_server(ipc_action_server_id_);
+  }
 
 protected:
   // Intra-process version of execute_goal_request_received_


### PR DESCRIPTION
This is kind of a workaround to have `wait_for_service` work with StubDDS.

There's no such `wait_for_service` API on DDS. It is implemented in `rclcpp` looking for changes in the node graph, using a `wait_set`, which is not supported on StubDDS.

So here, when waiting for a service, we first look into the intra-process services, which doesn't need the wait set. 

If after the timeout it doesn't find it, it'll look with the nodegraph, i.e. will crash since `rmw_wait` is not supported.

The new api `wait_for_intra_process_service_nanoseconds` could become public, so we could directly wait only for intra-process, avoiding the crash if after the timeout the service is not found.

