### PR TITLE
Some fixes

### DIFF
--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -214,10 +214,11 @@ protected:
   void
   set_on_new_event_callback(rcl_event_callback_t callback, const void * user_data);
 
-  rcl_event_t event_handle_;
-  size_t wait_set_event_index_;
   std::recursive_mutex callback_mutex_;
   std::function<void(size_t)> on_new_event_callback_{nullptr};
+
+  rcl_event_t event_handle_;
+  size_t wait_set_event_index_;
 };
 
 template<typename EventCallbackT, typename ParentHandleT>

--- a/rclcpp/src/rclcpp/qos_event.cpp
+++ b/rclcpp/src/rclcpp/qos_event.cpp
@@ -35,6 +35,8 @@ UnsupportedEventTypeException::UnsupportedEventTypeException(
 
 QOSEventHandlerBase::~QOSEventHandlerBase()
 {
+  std::lock_guard<std::recursive_mutex> lock(callback_mutex_);
+
   if (on_new_event_callback_) {
     clear_on_ready_callback();
   }


### PR DESCRIPTION
Some fixes for bugs which didn't appeared yet during testing, but could happen.

- Protect `on_new_event_callback_` with mutex before being read.
- Declare QoS event callback before event handle, to avoid possible data races when an event is destroyed while it's callback is being called.