### PR TITLE
qos-event callback fixes

### DIFF
--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -214,10 +214,11 @@ protected:
   void
   set_on_new_event_callback(rcl_event_callback_t callback, const void * user_data);
 
-  rcl_event_t event_handle_;
-  size_t wait_set_event_index_;
   std::recursive_mutex callback_mutex_;
   std::function<void(size_t)> on_new_event_callback_{nullptr};
+
+  rcl_event_t event_handle_;
+  size_t wait_set_event_index_;
 };
 
 template<typename EventCallbackT, typename ParentHandleT>

--- a/rclcpp/src/rclcpp/qos_event.cpp
+++ b/rclcpp/src/rclcpp/qos_event.cpp
@@ -35,9 +35,7 @@ UnsupportedEventTypeException::UnsupportedEventTypeException(
 
 QOSEventHandlerBase::~QOSEventHandlerBase()
 {
-  if (on_new_event_callback_) {
-    clear_on_ready_callback();
-  }
+  clear_on_ready_callback();
 
   if (rcl_event_fini(&event_handle_) != RCL_RET_OK) {
     RCUTILS_LOG_ERROR_NAMED(


### PR DESCRIPTION
reorder callback members in qos-events class and remove unprotected access to on_new_event_callback_

This PR replaces https://github.com/irobot-ros/rclcpp/pull/101

Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>