### PR TITLE
Add logs on failed take response/request

### DIFF
--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -80,6 +80,10 @@ ClientBase::take_type_erased_response(void * response_out, rmw_request_id_t & re
     &request_header_out,
     response_out);
   if (RCL_RET_CLIENT_TAKE_FAILED == ret) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("rclcpp"),
+      "Error in take_type_erased_response: RCL_RET_CLIENT_TAKE_FAILED. "
+      "Service name: %s", get_service_name());
     return false;
   } else if (RCL_RET_OK != ret) {
     rclcpp::exceptions::throw_from_rcl_error(ret);

--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -43,6 +43,10 @@ ServiceBase::take_type_erased_request(void * request_out, rmw_request_id_t & req
     &request_id_out,
     request_out);
   if (RCL_RET_SERVICE_TAKE_FAILED == ret) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("rclcpp"),
+      "Error in take_type_erased_request: RCL_RET_SERVICE_TAKE_FAILED. "
+      "Service name: %s", get_service_name());
     return false;
   } else if (RCL_RET_OK != ret) {
     rclcpp::exceptions::throw_from_rcl_error(ret);


### PR DESCRIPTION
Add logs on failed take response/request.
These failures seem to provoke errors on subsequent requests.
