### PR TITLE
Clang-tidy fix: Break for loop after moving unique_ptr

### DIFF
--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -419,6 +419,8 @@ private:
         if (std::next(it) == subscription_ids.end()) {
           // If this is the last subscription, give up ownership
           subscription->provide_intra_process_message(std::move(message));
+          // Nothing else to do, exit for loop
+          break;
         } else {
           // Copy the message since we have additional subscriptions to serve
           MessageUniquePtr copy_message;


### PR DESCRIPTION
Clang-tidy thinks this moved message can still be used in future iterations of the for loop, so we break
after move it.