### PR TITLE
Set lock free queue MAX_SEMA_SPINS = 0

### DIFF
--- a/rclcpp/include/rclcpp/experimental/buffers/concurrent_queue/concurrentqueue.h
+++ b/rclcpp/include/rclcpp/experimental/buffers/concurrent_queue/concurrentqueue.h
@@ -377,7 +377,7 @@ struct ConcurrentQueueDefaultTraits
 	// Recommended values are on the order of 1000-10000 unless the number of
 	// consumer threads exceeds the number of idle cores (in which case try 0-100).
 	// Only affects instances of the BlockingConcurrentQueue.
-	static const int MAX_SEMA_SPINS = 10000;
+	static const int MAX_SEMA_SPINS = 0;
 	
 	
 #ifndef MCDBGQ_USE_RELACY


### PR DESCRIPTION
There is significant CPU time reduction with this new setting, since we don't waste CPU cycles spinning 10K times after an event is dequeued.