### PR TITLE
Some fixes

### DIFF
--- a/rclcpp/src/rclcpp/executors/timers_manager.cpp
+++ b/rclcpp/src/rclcpp/executors/timers_manager.cpp
@@ -75,16 +75,9 @@ void TimersManager::start()
 
 void TimersManager::stop()
 {
-  // Nothing to do if the timers thread is not running
-  // or if another thread already signaled to stop.
-  if (!running_.exchange(false)) {
-    // Thread might be still running, despite the atomic bool
-    // 'running_' already set to false
-    if (timers_thread_.joinable()) {
-      timers_thread_.join();
-    }
-    return;
-  }
+  // Lock stop() function to prevent race condition in destructor
+  rclcpp::Lock lock(stop_mutex_);
+  running_ = false;
 
   // Notify the timers manager thread to wake up
   {

--- a/rclcpp/src/rclcpp/executors/timers_manager.cpp
+++ b/rclcpp/src/rclcpp/executors/timers_manager.cpp
@@ -78,6 +78,11 @@ void TimersManager::stop()
   // Nothing to do if the timers thread is not running
   // or if another thread already signaled to stop.
   if (!running_.exchange(false)) {
+    // Thread might be still running, despite the atomic bool
+    // 'running_' already set to false
+    if (timers_thread_.joinable()) {
+      timers_thread_.join();
+    }
     return;
   }
 

--- a/rclcpp/src/rclcpp/executors/timers_manager.cpp
+++ b/rclcpp/src/rclcpp/executors/timers_manager.cpp
@@ -237,9 +237,7 @@ void TimersManager::run_timers()
       if (time_to_sleep != std::chrono::nanoseconds::max()) {
         // Wait until timeout or notification that timers have been updated
         uint64_t timetosleep_ns = time_to_sleep.count(); // in nano-seconds
-        bool ok = timers_cv_.wait_for(timers_mutex_, timetosleep_ns);
-        assert(ok);
-        (void)ok;
+        timers_cv_.wait_for(timers_mutex_, timetosleep_ns);
       } else {
         // Wait until notification that timers have been updated
         while (!timers_updated_) {


### PR DESCRIPTION
Fixes:
- Remove not needed assert
- Timers manager: Fix data race - Unjoined thread causing segfault

This was the situation:
```
// Thread 1
run_timers() {
   while (rclcpp::ok(context_) && running_) {...}
   running_ = false; 
   // implicit stuff still happening here
}
```
```
// Thread 2
stop() {
  if (!running_.exchange(false)) {   return; } // Problem here!
  ... 
  // join thread if joinable
 }
```
Thread 2 assumed that if `running_` was set to `false` at the end of `run_timers()`, it meant that the function has exited and there is no need to `join` the thread. In reality, the function `run_timers()` keeps running for a bit after the last line was executed.
If the program finished, and the thread wasn't joined, a segfault will occur (and this actually happened most of the times).

Note: On Iron and Humble, we have already fixed this: 
https://github.com/ros2/rclcpp/blob/rolling/rclcpp/src/rclcpp/experimental/timers_manager.cpp#L97-L100
https://github.com/irobot-ros/events-executor/blob/humble-future-gcc8/irobot_events_executor/src/rclcpp/timers_manager.cpp#L82-L85


