### PR TITLE
Fix compiler error

### DIFF
--- a/rclcpp/include/rclcpp/any_service_callback.hpp
+++ b/rclcpp/include/rclcpp/any_service_callback.hpp
@@ -41,7 +41,7 @@ struct can_be_nullptr : std::false_type {};
 // We also test if `T &` can be assigned to `nullptr` to avoid the issue.
 template<typename T>
 struct can_be_nullptr<T, std::void_t<
-    decltype(std::declval<T>() == nullptr), decltype(std::declval<T &>() = nullptr)>>
+    decltype(std::declval<T>() == nullptr), decltype(std::declval<T &>())>>
   : std::true_type {};
 }  // namespace detail
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
@@ -15,7 +15,9 @@
 #ifndef RCLCPP__NODE_INTERFACES__NODE_BASE_HPP_
 #define RCLCPP__NODE_INTERFACES__NODE_BASE_HPP_
 
+#include <atomic>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
@@ -15,10 +15,10 @@
 #ifndef RCLCPP__NODE_INTERFACES__NODE_BASE_INTERFACE_HPP_
 #define RCLCPP__NODE_INTERFACES__NODE_BASE_INTERFACE_HPP_
 
+#include <atomic>
+#include <functional>
 #include <memory>
-#include <mutex>
 #include <string>
-#include <vector>
 
 #include "rcl/node.h"
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_graph.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph.hpp
@@ -15,7 +15,9 @@
 #ifndef RCLCPP__NODE_INTERFACES__NODE_GRAPH_HPP_
 #define RCLCPP__NODE_INTERFACES__NODE_GRAPH_HPP_
 
+#include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <map>
 #include <memory>
 #include <mutex>

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
@@ -15,9 +15,10 @@
 #ifndef RCLCPP__NODE_INTERFACES__NODE_PARAMETERS_HPP_
 #define RCLCPP__NODE_INTERFACES__NODE_PARAMETERS_HPP_
 
+#include <list>
 #include <map>
 #include <memory>
-#include <list>
+#include <mutex>
 #include <string>
 #include <vector>
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -15,8 +15,8 @@
 #ifndef RCLCPP__NODE_INTERFACES__NODE_PARAMETERS_INTERFACE_HPP_
 #define RCLCPP__NODE_INTERFACES__NODE_PARAMETERS_INTERFACE_HPP_
 
+#include <functional>
 #include <map>
-#include <memory>
 #include <string>
 #include <vector>
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_topics_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_topics_interface.hpp
@@ -15,8 +15,6 @@
 #ifndef RCLCPP__NODE_INTERFACES__NODE_TOPICS_INTERFACE_HPP_
 #define RCLCPP__NODE_INTERFACES__NODE_TOPICS_INTERFACE_HPP_
 
-#include <functional>
-#include <memory>
 #include <string>
 
 #include "rcl/publisher.h"


### PR DESCRIPTION
Fix:

error: no match for 'operator=' .. decltype(std::declval<T &>() = nullptr) in `any_service_callback.hpp`