### PR TITLE
Fixes

### DIFF
--- a/rclcpp/include/rclcpp/executors/events_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor.hpp
@@ -73,7 +73,7 @@ public:
 
   /// Default destrcutor.
   RCLCPP_PUBLIC
-  virtual ~EventsExecutor() = default;
+  virtual ~EventsExecutor();
 
   /// Events executor implementation of spin.
   /**

--- a/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
@@ -41,7 +41,12 @@ public:
 
   // Destructor
   RCLCPP_PUBLIC
-  virtual ~EventsExecutorNotifyWaitable() = default;
+  virtual ~EventsExecutorNotifyWaitable()
+  {
+    for (auto & gc : notify_guard_conditions_) {
+      gc->set_on_trigger_callback(nullptr);
+    }
+  }
 
   // The function is a no-op, since we only care of waking up the executor
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/executors/timers_manager.hpp
+++ b/rclcpp/include/rclcpp/executors/timers_manager.hpp
@@ -150,6 +150,12 @@ public:
    */
   std::chrono::nanoseconds get_head_timeout();
 
+  /**
+   * @brief Function to check if the timers thread is running
+   * @return true if timers thread is running
+   */
+  bool is_running();
+
 private:
   RCLCPP_DISABLE_COPY(TimersManager)
 

--- a/rclcpp/src/rclcpp/executors/events_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/events_executor.cpp
@@ -52,6 +52,26 @@ EventsExecutor::EventsExecutor(
   entities_collector_->add_waitable(executor_notifier_);
 }
 
+EventsExecutor::~EventsExecutor()
+{
+  // Set 'spinning' to false and get previous value
+  auto executor_was_spinning = spinning.exchange(false);
+
+  if (executor_was_spinning) {
+    // Trigger the shutdown guard condition.
+    // This way, the 'events_queue_' will wake up since a new event has arrived.
+    // Then since 'spinning' is now false, the spin loop will exit.
+    shutdown_guard_condition_->trigger();
+
+    // The timers manager thread is stopped at the end of spin().
+    // We have to wait for timers manager thread to exit, otherwise
+    // the 'timers_manager_' will be destroyed while still being used on spin().
+    while (timers_manager_->is_running()) {
+      std::this_thread::sleep_for(1ms);
+    }
+  }
+}
+
 void
 EventsExecutor::spin()
 {

--- a/rclcpp/src/rclcpp/executors/timers_manager.cpp
+++ b/rclcpp/src/rclcpp/executors/timers_manager.cpp
@@ -284,3 +284,8 @@ void TimersManager::remove_timer(TimerPtr timer)
 
   timer->clear_on_reset_callback();
 }
+
+bool TimersManager::is_running()
+{
+  return running_;
+}


### PR DESCRIPTION
Fixes
* Make sure we exit `spin()` before destroying members of `EventsExecutor`, during `~EventsExecutor`:
[Add TimersManager::is_running() / Exit spin() before destroying stuff](https://github.com/irobot-ros/rclcpp/commit/8305c04921a0489dbc733cc491e8c42ef5f52e45)
* [Unset gc's callback on ~EventsExecutorNotifyWaitable()](https://github.com/irobot-ros/rclcpp/commit/8383cc5fb43b39ae79b323631b8e202769f2515e)