### PR TITLE
Unset gc's callback on ~EventsExecutorNotifyWaitable()

### DIFF
--- a/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
+++ b/rclcpp/include/rclcpp/executors/events_executor_notify_waitable.hpp
@@ -41,7 +41,12 @@ public:
 
   // Destructor
   RCLCPP_PUBLIC
-  virtual ~EventsExecutorNotifyWaitable() = default;
+  virtual ~EventsExecutorNotifyWaitable()
+  {
+    for (auto & gc : notify_guard_conditions_) {
+      gc->set_on_trigger_callback(nullptr);
+    }
+  }
 
   // The function is a no-op, since we only care of waking up the executor
   RCLCPP_PUBLIC


### PR DESCRIPTION
The notify waitable has set callbacks to the guard conditions added to it.
When this waitable is destroyed, it should remove those callbacks from the guard conditions.
