### PR TITLE
Galactic: Fix data race on parameter event

### DIFF
--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -131,6 +131,7 @@ protected:
 
 private:
   // Preserve the node reference
+  std::mutex node_base_lock_;
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
   rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_;
   rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_;


### PR DESCRIPTION
The callback 'on_parameter_event' was internally accessing node_base_, which could be already destroyed.

Cherry pick https://github.com/ros2/rclcpp/pull/2320