### PR TITLE
Fixes for IPC Actions

### DIFF
--- a/rclcpp/include/rclcpp/experimental/action_client_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/action_client_intra_process.hpp
@@ -100,6 +100,12 @@ public:
   {
     (void) wait_set;
 
+    is_goal_response_ready_ = goal_response_buffer_->has_data();
+    is_result_response_ready_ = result_response_buffer_->has_data();
+    is_cancel_response_ready_ = cancel_response_buffer_->has_data();
+    is_feedback_ready_ = feedback_buffer_->has_data();
+    is_status_ready_ = status_buffer_->has_data();
+
     return is_feedback_ready_ ||
            is_status_ready_ ||
            is_goal_response_ready_ ||
@@ -130,7 +136,6 @@ public:
   {
     goal_response_buffer_->add(std::move(goal_response));
     gc_.trigger();
-    is_goal_response_ready_ = true;
     invoke_on_ready_callback(EventType::GoalResponse);
   }
 
@@ -138,7 +143,6 @@ public:
   {
     result_response_buffer_->add(std::move(result_response));
     gc_.trigger();
-    is_result_response_ready_ = true;
     invoke_on_ready_callback(EventType::ResultResponse);
   }
 
@@ -146,7 +150,6 @@ public:
   {
     cancel_response_buffer_->add(std::move(cancel_response));
     gc_.trigger();
-    is_cancel_response_ready_ = true;
     invoke_on_ready_callback(EventType::CancelResponse);
   }
 
@@ -154,7 +157,6 @@ public:
   {
     feedback_buffer_->add(std::move(feedback));
     gc_.trigger();
-    is_feedback_ready_ = true;
     invoke_on_ready_callback(EventType::FeedbackReady);
   }
 
@@ -162,7 +164,6 @@ public:
   {
     status_buffer_->add(std::move(status));
     gc_.trigger();
-    is_status_ready_ = true;
     invoke_on_ready_callback(EventType::StatusReady);
   }
 
@@ -217,11 +218,6 @@ public:
 
   void execute(std::shared_ptr<void> & data)
   {
-    // How to handle case when more than one flag is ready?
-    // For example, feedback and status are both ready, guard condition triggered
-    // twice, but we process a single entity here.
-    // On the default executor using a waitset, waitables are checked twice if ready,
-    // so that fixes the issue. Check if this is a problem with EventsExecutor.
     if (!data) {
       throw std::runtime_error("'data' is empty");
     }

--- a/rclcpp/include/rclcpp/experimental/action_client_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/action_client_intra_process.hpp
@@ -181,23 +181,36 @@ public:
   take_data() override
   {
     if (is_goal_response_ready_) {
-      auto data = std::move(goal_response_buffer_->consume());
-      return std::static_pointer_cast<void>(data);
+      if (goal_response_buffer_->has_data()) {
+        auto data = std::move(goal_response_buffer_->consume());
+        return std::static_pointer_cast<void>(data);
+      }
     } else if (is_result_response_ready_) {
-      auto data = std::move(result_response_buffer_->consume());
-      return std::static_pointer_cast<void>(data);
+      if (result_response_buffer_->has_data()) {
+        auto data = std::move(result_response_buffer_->consume());
+        return std::static_pointer_cast<void>(data);
+      }
     } else if (is_cancel_response_ready_) {
-      auto data = std::move(cancel_response_buffer_->consume());
-      return std::static_pointer_cast<void>(data);
+      if (cancel_response_buffer_->has_data()) {
+        auto data = std::move(cancel_response_buffer_->consume());
+        return std::static_pointer_cast<void>(data);
+      }
     } else if (is_feedback_ready_) {
-      auto data = std::move(feedback_buffer_->consume());
-      return std::static_pointer_cast<void>(data);
+      if (feedback_buffer_->has_data()) {
+        auto data = std::move(feedback_buffer_->consume());
+        return std::static_pointer_cast<void>(data);
+      }
     } else if (is_status_ready_) {
-      auto data = std::move(status_buffer_->consume());
-      return std::static_pointer_cast<void>(data);
+      if (status_buffer_->has_data()) {
+        auto data = std::move(status_buffer_->consume());
+        return std::static_pointer_cast<void>(data);
+      }
     } else {
       throw std::runtime_error("Taking data from intra-process action client but nothing is ready");
     }
+
+    // This can happen when there were more events than elements in the ring buffer
+    return nullptr;
   }
 
   std::shared_ptr<void>

--- a/rclcpp/include/rclcpp/experimental/action_client_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/action_client_intra_process.hpp
@@ -51,13 +51,30 @@ public:
 
   // Useful aliases for the action client data types
   using ResponseCallback = std::function<void (std::shared_ptr<void>)>;
+
+  // Aliases for the GoalResponse ring buffer
   using GoalResponse = typename ActionT::Impl::SendGoalService::Response;
   using GoalResponseSharedPtr = typename std::shared_ptr<GoalResponse>;
+  using GoalResponseDataPair = typename std::pair<uint64_t /*Goal ID*/, GoalResponseSharedPtr>;
+  using GoalResponseVoidDataPair = typename std::pair<uint64_t /*Goal ID*/, std::shared_ptr<void>>;
+  using GoalResponsePairSharedPtr = typename std::shared_ptr<GoalResponseDataPair>;
+
+  // Aliases for the ResultResponse ring buffer
   using ResultResponse = typename ActionT::Impl::GetResultService::Response;
   using ResultResponseSharedPtr = typename std::shared_ptr<ResultResponse>;
+  using ResultResponseDataPair = typename std::pair<uint64_t /*Goal ID*/, ResultResponseSharedPtr>;
+  using ResultResponseVoidDataPair = typename std::pair<uint64_t /*Goal ID*/, std::shared_ptr<void>>;
+  using ResultResponsePairSharedPtr = typename std::shared_ptr<ResultResponseDataPair>;
+
+  // Aliases for the CancelResponse ring buffer
+  using CancelResponse = typename ActionT::Impl::CancelGoalService::Response;
+  using CancelResponseSharedPtr = typename std::shared_ptr<CancelResponse>;
+  using CancelResponseDataPair = typename std::pair<uint64_t /*Goal ID*/, CancelResponseSharedPtr>;
+  using CancelResponseVoidDataPair = typename std::pair<uint64_t /*Goal ID*/, std::shared_ptr<void>>;
+  using CancelResponsePairSharedPtr = typename std::shared_ptr<CancelResponseDataPair>;
+
   using FeedbackMessage = typename ActionT::Impl::FeedbackMessage;
   using FeedbackSharedPtr = typename std::shared_ptr<FeedbackMessage>;
-  using CancelGoalSharedPtr = typename std::shared_ptr<void>;
   using GoalStatusSharedPtr = typename std::shared_ptr<void>;
 
   ActionClientIntraProcess(
@@ -66,20 +83,18 @@ public:
     const rcl_action_client_depth_t & qos_history,
     ResponseCallback goal_status_callback,
     ResponseCallback feedback_callback)
-  : goal_status_callback_(goal_status_callback),
-    feedback_callback_(feedback_callback),
-    ActionClientIntraProcessBase(
+  : ActionClientIntraProcessBase(
       context,
       action_name,
       QoS(qos_history.goal_service_depth))
   {
     // Create the intra-process buffers
     goal_response_buffer_ =
-      rclcpp::experimental::create_service_intra_process_buffer<GoalResponseSharedPtr>(
+      rclcpp::experimental::create_service_intra_process_buffer<GoalResponsePairSharedPtr>(
       QoS(qos_history.goal_service_depth));
 
     result_response_buffer_ =
-      rclcpp::experimental::create_service_intra_process_buffer<ResultResponseSharedPtr>(
+      rclcpp::experimental::create_service_intra_process_buffer<ResultResponsePairSharedPtr>(
       QoS(qos_history.result_service_depth));
 
     status_buffer_ =
@@ -91,8 +106,11 @@ public:
       QoS(qos_history.feedback_topic_depth));
 
     cancel_response_buffer_ =
-      rclcpp::experimental::create_service_intra_process_buffer<CancelGoalSharedPtr>(
+      rclcpp::experimental::create_service_intra_process_buffer<CancelResponsePairSharedPtr>(
       QoS(qos_history.cancel_service_depth));
+
+    set_response_callback_to_event_type(EventType::FeedbackReady, feedback_callback);
+    set_response_callback_to_event_type(EventType::StatusReady, goal_status_callback);
   }
 
   virtual ~ActionClientIntraProcess() = default;
@@ -114,53 +132,77 @@ public:
            is_result_response_ready_;
   }
 
-  void store_goal_response_callback(ResponseCallback callback)
+
+  // Store the callback to be called with the (accepted/rejected) reponse from the sever
+  void store_goal_response_callback(size_t goal_id, ResponseCallback response_callback)
   {
-    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
-    goal_response_callback_ = callback;
-    if (events_callbacks_set()) {
-      set_callback_to_event_type(EventType::GoalResponse, generic_callback_);
+    set_response_callback_to_event_type(EventType::GoalResponse, response_callback, goal_id);
+  }
+
+  // Store the callback to be called with the reponse from the sever, when ready.
+  void store_result_response_callback(size_t goal_id, ResponseCallback callback)
+  {
+    set_response_callback_to_event_type(EventType::ResultResponse, callback, goal_id);
+
+    EventInfo& result_response_event_info = get_event_info(goal_id, EventType::ResultResponse);
+
+    // Check if there was a previous event which needed the result response callback
+    if (result_response_event_info.has_event) {
+      invoke_on_ready_callback(EventType::ResultResponse, goal_id);
+      result_response_event_info.has_event = false;
+      result_response_event_info.unread_count = 0;
     }
   }
 
-  void store_cancel_goal_callback(ResponseCallback callback)
+  void store_cancel_goal_callback(size_t goal_id, ResponseCallback callback)
   {
-    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
-    cancel_goal_callback_ = callback;
-    if (events_callbacks_set()) {
-      set_callback_to_event_type(EventType::CancelResponse, generic_callback_);
+    set_response_callback_to_event_type(EventType::CancelResponse, callback, goal_id);
+  }
+
+  // Store goal response from server
+  void store_ipc_action_goal_response(
+    GoalResponseSharedPtr goal_response,
+    size_t goal_id)
+  {
+    goal_response_buffer_->add(
+      std::make_shared<GoalResponseDataPair>(
+        std::make_pair(goal_id, std::move(goal_response))));
+
+    gc_.trigger();
+
+    invoke_on_ready_callback(EventType::GoalResponse, goal_id);
+  }
+
+  void store_ipc_action_result_response(
+    ResultResponseSharedPtr result_response,
+    size_t goal_id)
+  {
+    result_response_buffer_->add(
+      std::make_shared<ResultResponseDataPair>(
+        std::make_pair(goal_id, std::move(result_response))));
+
+    gc_.trigger();
+
+    EventInfo& result_response_event_info = get_event_info(goal_id, EventType::ResultResponse);
+
+    // Don't invoke the on ready callback if we still not have the callback to process the event
+    if(!result_response_event_info.response_callback) {
+      result_response_event_info.has_event = true;
+      return;
     }
+    invoke_on_ready_callback(EventType::ResultResponse, goal_id);
   }
 
-  void store_result_response_callback(ResponseCallback callback)
+  void store_ipc_action_cancel_response(
+    CancelResponseSharedPtr cancel_response,
+    size_t goal_id)
   {
-    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
-    result_response_callback_ = callback;
-    if (events_callbacks_set()) {
-      set_callback_to_event_type(EventType::ResultResponse, generic_callback_);
-    }
-  }
+    cancel_response_buffer_->add(
+      std::make_shared<CancelResponseDataPair>(
+        std::make_pair(goal_id, std::move(cancel_response))));
 
-  // Store responses from server
-  void store_ipc_action_goal_response(GoalResponseSharedPtr goal_response)
-  {
-    goal_response_buffer_->add(std::move(goal_response));
     gc_.trigger();
-    invoke_on_ready_callback(EventType::GoalResponse);
-  }
-
-  void store_ipc_action_result_response(ResultResponseSharedPtr result_response)
-  {
-    result_response_buffer_->add(std::move(result_response));
-    gc_.trigger();
-    invoke_on_ready_callback(EventType::ResultResponse);
-  }
-
-  void store_ipc_action_cancel_response(CancelGoalSharedPtr cancel_response)
-  {
-    cancel_response_buffer_->add(std::move(cancel_response));
-    gc_.trigger();
-    invoke_on_ready_callback(EventType::CancelResponse);
+    invoke_on_ready_callback(EventType::CancelResponse, goal_id);
   }
 
   void store_ipc_action_feedback(FeedbackSharedPtr feedback)
@@ -238,6 +280,64 @@ public:
     return take_data();
   }
 
+  void execute_goal_response(std::shared_ptr<void> & response_pair)
+  {
+    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
+
+    auto goal_response_pair = std::static_pointer_cast<GoalResponseVoidDataPair>(response_pair);
+    auto goal_id = goal_response_pair->first;
+
+    // Get the callback matching this server response
+    auto goal_response_callback = get_callback_for_event_type(goal_id, EventType::GoalResponse);
+
+    if (!goal_response_callback) {
+      throw std::runtime_error("IPC ActionClient: goal_response_callback not set!");
+    }
+
+    goal_response_callback(std::move(goal_response_pair->second));
+
+    // Remove entry for this goal ID and event type, since the result callback
+    // it's keeping in scope shared pointers
+    remove_entry_from_event_info_multi_map_(goal_id, EventType::GoalResponse);
+  }
+
+  void execute_result_response(std::shared_ptr<void> & result_pair)
+  {
+    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
+
+    auto result_response_pair = std::static_pointer_cast<ResultResponseVoidDataPair>(result_pair);
+    auto goal_id = result_response_pair->first;
+
+    // Get the callback matching this server response
+    auto result_response_callback = get_callback_for_event_type(goal_id, EventType::ResultResponse);
+
+    if (!result_response_callback) {
+      throw std::runtime_error("IPC ActionClient: result_response_callback not set!");
+    }
+
+    result_response_callback(std::move(result_response_pair->second));
+
+    remove_entry_from_event_info_multi_map_(goal_id, EventType::ResultResponse);
+  }
+
+  void execute_cancel_response(std::shared_ptr<void> & cancel_pair)
+  {
+    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
+
+    auto cancel_response_pair = std::static_pointer_cast<CancelResponseVoidDataPair>(cancel_pair);
+    auto goal_id = cancel_response_pair->first;
+
+    // Get the callback matching this server response
+    auto cancel_response_callback = get_callback_for_event_type(goal_id, EventType::CancelResponse);
+
+    if (!cancel_response_callback) {
+      throw std::runtime_error("IPC ActionClient: cancel_response_callback not set!");
+    }
+
+    cancel_response_callback(std::move(cancel_response_pair->second));
+
+    remove_entry_from_event_info_multi_map_(goal_id, EventType::CancelResponse);
+  }
 
   void execute(std::shared_ptr<void> & data)
   {
@@ -246,34 +346,25 @@ public:
       return;
     }
 
-    if (is_goal_response_ready_) {
-      std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
-      is_goal_response_ready_ = false;
-      goal_response_callback_(std::move(data));
-      // Unset the callback after use, since it's keeping in scope shared pointers
-      goal_response_callback_ = nullptr;
-      unset_callback_to_event_type(EventType::GoalResponse);
-    } else if (is_result_response_ready_) {
-      std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
-      is_result_response_ready_ = false;
-      result_response_callback_(std::move(data));
-      // Unset the callback after use, since it's keeping in scope shared pointers
-      result_response_callback_ = nullptr;
-      unset_callback_to_event_type(EventType::ResultResponse);
-    } else if (is_cancel_response_ready_) {
-      std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
-      is_cancel_response_ready_ = false;
-      cancel_goal_callback_(std::move(data));
-      // Unset the callback after use, since it's keeping in scope shared pointers
-      cancel_goal_callback_ = nullptr;
-      unset_callback_to_event_type(EventType::CancelResponse);
-    } else if (is_feedback_ready_) {
-      is_feedback_ready_ = false;
-      feedback_callback_(std::move(data));
-    } else if (is_status_ready_) {
-      is_status_ready_ = false;
-      goal_status_callback_(std::move(data));
-    } else {
+    if (is_goal_response_ready_.exchange(false)) {
+      execute_goal_response(data);
+    }
+    else if (is_result_response_ready_.exchange(false)) {
+      execute_result_response(data);
+    }
+    else if (is_cancel_response_ready_.exchange(false)) {
+      execute_cancel_response(data);
+    }
+    else if (is_feedback_ready_.exchange(false)) {
+      // Get the callback matching this server response
+      auto feedback_callback = get_callback_for_event_type(0, EventType::FeedbackReady);
+      feedback_callback(std::move(data));
+    }
+    else if (is_status_ready_.exchange(false)) {
+      auto goal_status_callback = get_callback_for_event_type(0, EventType::StatusReady);
+      goal_status_callback(std::move(data));
+    }
+    else {
       throw std::runtime_error("Executing intra-process action client but nothing is ready");
     }
   }
@@ -282,15 +373,12 @@ protected:
   // Mutex to proctect callbacks
   std::recursive_mutex reentrant_mutex_;
 
-  ResponseCallback goal_status_callback_;
-  ResponseCallback feedback_callback_;
-
-  // Create buffers to store data coming from server
+  // Buffers to store data coming from server
   typename rclcpp::experimental::buffers::ServiceIntraProcessBuffer<
-    GoalResponseSharedPtr>::UniquePtr goal_response_buffer_;
+    GoalResponsePairSharedPtr>::UniquePtr goal_response_buffer_;
 
   typename rclcpp::experimental::buffers::ServiceIntraProcessBuffer<
-    ResultResponseSharedPtr>::UniquePtr result_response_buffer_;
+    ResultResponsePairSharedPtr>::UniquePtr result_response_buffer_;
 
   typename rclcpp::experimental::buffers::ServiceIntraProcessBuffer<
     FeedbackSharedPtr>::UniquePtr feedback_buffer_;
@@ -298,8 +386,8 @@ protected:
   rclcpp::experimental::buffers::ServiceIntraProcessBuffer<
     GoalStatusSharedPtr>::UniquePtr status_buffer_;
 
-  rclcpp::experimental::buffers::ServiceIntraProcessBuffer<
-    CancelGoalSharedPtr>::UniquePtr cancel_response_buffer_;
+  typename rclcpp::experimental::buffers::ServiceIntraProcessBuffer<
+    CancelResponsePairSharedPtr>::UniquePtr cancel_response_buffer_;
 
   std::atomic<bool> is_feedback_ready_{false};
   std::atomic<bool> is_status_ready_{false};

--- a/rclcpp/include/rclcpp/experimental/action_client_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/action_client_intra_process_base.hpp
@@ -210,10 +210,6 @@ protected:
     }
   }
 
-private:
-  std::string action_name_;
-  QoS qos_profile_;
-
   void set_callback_to_event_type(
     EventType event_type,
     std::function<void(size_t, int)> callback)
@@ -261,6 +257,10 @@ private:
     }
     return false;
   }
+
+private:
+  std::string action_name_;
+  QoS qos_profile_;
 
   std::function<void(size_t)>
   create_event_type_callback(

--- a/rclcpp/include/rclcpp/experimental/action_client_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/action_client_intra_process_base.hpp
@@ -247,7 +247,8 @@ protected:
   }
 
   // Function to retrieve a reference to an EventInfo matching the hashed_guuid and EventType
-  EventInfo& get_event_info(size_t goal_id, EventType event_type) {
+  EventInfo& get_event_info(size_t goal_id, EventType event_type)
+  {
     auto range = event_info_multi_map_.equal_range(goal_id);
     for (auto it = range.first; it != range.second; ++it) {
       if (it->second.event_type == event_type) {
@@ -278,7 +279,8 @@ protected:
   }
 
   // Function to remove an entry from event_info_multi_map_ for a particular goal_id and EventType
-  void remove_entry_from_event_info_multi_map_(size_t goal_id, EventType event_type) {
+  void remove_entry_from_event_info_multi_map_(size_t goal_id, EventType event_type)
+  {
     std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
 
     auto range = event_info_multi_map_.equal_range(goal_id);

--- a/rclcpp/include/rclcpp/experimental/action_server_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/action_server_intra_process.hpp
@@ -197,28 +197,30 @@ public:
       return;
     }
 
-    if (goal_request_ready_) {
-      goal_request_ready_ = false;
+    if (goal_request_ready_.exchange(false))
+    {
       if (execute_goal_request_received_) {
         auto goal_request_data = std::static_pointer_cast<GoalRequestDataPair>(data);
         execute_goal_request_received_(std::move(goal_request_data));
       }
-    } else if (cancel_request_ready_) {
-      cancel_request_ready_ = false;
+    }
+    else if (cancel_request_ready_.exchange(false)) {
       if (execute_cancel_request_received_) {
         auto cancel_goal_data = std::static_pointer_cast<CancelRequestDataPair>(data);
         execute_cancel_request_received_(std::move(cancel_goal_data));
       }
-    } else if (result_request_ready_) {
-      result_request_ready_ = false;
+    }
+    else if (result_request_ready_.exchange(false)) {
       if (execute_result_request_received_) {
         auto result_request_data = std::static_pointer_cast<ResultRequestDataPair>(data);
         execute_result_request_received_(std::move(result_request_data));
       }
-    } else if (goal_expired_) {
+    }
+    else if (goal_expired_) {
       // TODO(mauropasse): Handle goal expired case
       // execute_check_expired_goals();
-    } else {
+    }
+    else {
       throw std::runtime_error("Executing action server but nothing is ready");
     }
   }

--- a/rclcpp/include/rclcpp/experimental/action_server_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/action_server_intra_process.hpp
@@ -102,6 +102,10 @@ public:
   {
     (void)wait_set;
 
+    goal_request_ready_ = goal_request_buffer_->has_data();
+    cancel_request_ready_ = cancel_request_buffer_->has_data();
+    result_request_ready_ = result_request_buffer_->has_data();
+
     return goal_request_ready_ ||
            cancel_request_ready_ ||
            result_request_ready_ ||
@@ -115,7 +119,6 @@ public:
     goal_request_buffer_->add(
       std::make_pair(ipc_action_client_id, std::move(goal_request)));
     gc_.trigger();
-    goal_request_ready_ = true;
     invoke_on_ready_callback(EventType::GoalRequest);
   }
 
@@ -126,7 +129,6 @@ public:
     result_request_buffer_->add(
       std::make_pair(ipc_action_client_id, std::move(result_request)));
     gc_.trigger();
-    result_request_ready_ = true;
     invoke_on_ready_callback(EventType::ResultRequest);
   }
 
@@ -137,7 +139,6 @@ public:
     cancel_request_buffer_->add(
       std::make_pair(ipc_action_client_id, std::move(cancel_request)));
     gc_.trigger();
-    cancel_request_ready_ = true;
     invoke_on_ready_callback(EventType::CancelGoal);
   }
 

--- a/rclcpp/include/rclcpp/experimental/action_server_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/action_server_intra_process_base.hpp
@@ -127,32 +127,36 @@ public:
               "is not callable.");
     }
 
-    set_callback_to_event_type(EventType::GoalRequest, callback);
-    set_callback_to_event_type(EventType::CancelGoal, callback);
-    set_callback_to_event_type(EventType::ResultRequest, callback);
+    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
+
+    on_ready_callback_ = callback;
+
+    for (auto& pair : event_type_to_unread_count_) {
+      auto & event_type = pair.first;
+      auto & unread_count = pair.second;
+      if (unread_count) {
+        on_ready_callback_(unread_count, static_cast<int>(event_type));
+        unread_count = 0;
+      }
+    }
   }
 
   void
   clear_on_ready_callback() override
   {
     std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
-    event_type_to_on_ready_callback_.clear();
+    on_ready_callback_ = nullptr;
   }
 
 protected:
   std::recursive_mutex reentrant_mutex_;
   rclcpp::GuardCondition gc_;
 
-  // Action server on ready callbacks and unread count.
-  // These callbacks can be set by the user to be notified about new events
-  // on the action server like a new goal request, result request or a cancel goal request.
-  // These events have a counter associated with them, counting the amount of events
-  // that happened before having assigned a callback for them.
-  using EventTypeOnReadyCallback = std::function<void (size_t)>;
-  using CallbackUnreadCountPair = std::pair<EventTypeOnReadyCallback, size_t>;
+  // Map the different action server event types to their unread count.
+  std::unordered_map<EventType, size_t> event_type_to_unread_count_;
 
-  // Map the different action server event types to their callbacks and unread count.
-  std::unordered_map<EventType, CallbackUnreadCountPair> event_type_to_on_ready_callback_;
+  // Generic events callback
+  std::function<void(size_t, int)> on_ready_callback_{nullptr};
 
   // Invoke the callback to be called when the action server has a new event
   void
@@ -160,24 +164,19 @@ protected:
   {
     std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
 
-    // Search for a callback for this event type
-    auto it = event_type_to_on_ready_callback_.find(event_type);
+    if (on_ready_callback_) {
+      on_ready_callback_(1, static_cast<int>(event_type));
+      return;
+    }
 
-    if (it != event_type_to_on_ready_callback_.end()) {
-      auto & on_ready_callback = it->second.first;
-      // If there's a callback associated with this event type, call it
-      if (on_ready_callback) {
-        on_ready_callback(1);
-      } else {
-        // We don't have a callback for this event type yet,
-        // increase its event counter.
-        auto & event_type_unread_count = it->second.second;
-        event_type_unread_count++;
-      }
+    auto it = event_type_to_unread_count_.find(event_type);
+    if (it != event_type_to_unread_count_.end()) {
+        auto & unread_count = it->second;
+        // Entry exists, increment unread counter
+        unread_count++;
     } else {
-      // No entries found for this event type, create one
-      // with an emtpy callback and one unread event.
-      event_type_to_on_ready_callback_.emplace(event_type, std::make_pair(nullptr, 1));
+        // Entry doesn't exist, create new with unread_count = 1
+        event_type_to_unread_count_[event_type] = 1;
     }
   }
 
@@ -185,63 +184,6 @@ private:
   std::string action_name_;
   QoS qos_profile_;
 
-  void set_callback_to_event_type(
-    EventType event_type,
-    std::function<void(size_t, int)> callback)
-  {
-    auto new_callback = create_event_type_callback(callback, event_type);
-
-    std::lock_guard<std::recursive_mutex> lock(reentrant_mutex_);
-
-    // Check if we have already an entry for this event type
-    auto it = event_type_to_on_ready_callback_.find(event_type);
-
-    if (it != event_type_to_on_ready_callback_.end()) {
-      // We have an entry for this event type, check how many
-      // events of this event type happened so far.
-      auto & event_type_unread_count = it->second.second;
-      if (event_type_unread_count) {
-        new_callback(event_type_unread_count);
-      }
-      event_type_unread_count = 0;
-      // Set the new callback for this event type
-      auto & event_type_on_ready_callback = it->second.first;
-      event_type_on_ready_callback = new_callback;
-    } else {
-      // We had no entries for this event type, create one
-      // with the new callback and zero as unread count.
-      event_type_to_on_ready_callback_.emplace(event_type, std::make_pair(new_callback, 0));
-    }
-  }
-
-  std::function<void(size_t)>
-  create_event_type_callback(
-    std::function<void(size_t, int)> callback,
-    EventType event_type)
-  {
-    // Note: we bind the int identifier argument to this waitable's entity types
-    auto new_callback =
-      [callback, event_type, this](size_t number_of_events) {
-        try {
-          callback(number_of_events, static_cast<int>(event_type));
-        } catch (const std::exception & exception) {
-          RCLCPP_ERROR_STREAM(
-            rclcpp::get_logger("rclcpp_action"),
-            "rclcpp::experimental::ActionServerIntraProcessBase@" << this <<
-              " caught " << rmw::impl::cpp::demangle(exception) <<
-              " exception in user-provided callback for the 'on ready' callback: " <<
-              exception.what());
-        } catch (...) {
-          RCLCPP_ERROR_STREAM(
-            rclcpp::get_logger("rclcpp_action"),
-            "rclcpp::experimental::ActionServerIntraProcessBase@" << this <<
-              " caught unhandled exception in user-provided callback " <<
-              "for the 'on ready' callback");
-        }
-      };
-
-    return new_callback;
-  }
 };
 
 }  // namespace experimental

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -499,7 +499,8 @@ public:
       }
     }
 
-    throw std::runtime_error("No action clients match the specified ID.");
+    RCLCPP_WARN(rclcpp::get_logger("rclcpp"), "No action clients match the specified ID: %p", ipc_action_client_id);
+    return nullptr;
   }
 
   /// Gets an ActionServerIntraProcess<ActionT> matching an intra-process action client ID
@@ -517,7 +518,8 @@ public:
     auto action_client_it = action_clients_to_servers_.find(ipc_action_client_id);
 
     if (action_client_it == action_clients_to_servers_.end()) {
-      throw std::runtime_error("No action clients match the specified ID.");
+      RCLCPP_WARN(rclcpp::get_logger("rclcpp"), "No action clients match the specified ID: %p", ipc_action_client_id);
+      return nullptr;
     }
 
     uint64_t action_service_id = action_client_it->second;
@@ -564,6 +566,9 @@ public:
 
     if (client) {
       client->store_goal_response_callback(callback);
+    } else {
+      // Client went out of scope
+      return;
     }
 
     // Now lets send the goal request
@@ -597,6 +602,9 @@ public:
 
     if (client) {
       client->store_cancel_goal_callback(callback);
+    } else {
+      // Client went out of scope
+      return;
     }
 
     // Now lets send the cancel request
@@ -629,6 +637,9 @@ public:
 
     if (client) {
       client->store_result_response_callback(callback);
+    } else {
+      // Client went out of scope
+      return;
     }
 
     // Now lets send the result request to the server

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -551,27 +551,13 @@ public:
    *
    * \param ipc_action_client_id the id of the action client sending the goal request
    * \param goal_request the action client's goal request data.
-   * \param callback the callback to be called when the server sends the goal response
    */
   template<typename ActionT, typename RequestT>
   void
   intra_process_action_send_goal_request(
     uint64_t ipc_action_client_id,
-    RequestT goal_request,
-    std::function<void(std::shared_ptr<void>)> callback)
+    RequestT goal_request)
   {
-    // First, lets store the client callback to be called when the
-    // server sends the goal response
-    auto client = get_intra_process_action_client<ActionT>(ipc_action_client_id);
-
-    if (client) {
-      client->store_goal_response_callback(callback);
-    } else {
-      // Client went out of scope
-      return;
-    }
-
-    // Now lets send the goal request
     auto service = get_matching_intra_process_action_server<ActionT>(ipc_action_client_id);
 
     if (service) {
@@ -587,27 +573,13 @@ public:
    *
    * \param ipc_action_client_id the id of the action client sending the cancel request
    * \param cancel_request the action client's cancel request data.
-   * \param callback the callback to be called when the server sends the cancel response
    */
   template<typename ActionT, typename CancelT>
   void
   intra_process_action_send_cancel_request(
     uint64_t ipc_action_client_id,
-    CancelT cancel_request,
-    std::function<void(std::shared_ptr<void>)> callback)
+    CancelT cancel_request)
   {
-    // First, lets store the client callback to be called when the
-    // server sends the cancel response
-    auto client = get_intra_process_action_client<ActionT>(ipc_action_client_id);
-
-    if (client) {
-      client->store_cancel_goal_callback(callback);
-    } else {
-      // Client went out of scope
-      return;
-    }
-
-    // Now lets send the cancel request
     auto service = get_matching_intra_process_action_server<ActionT>(ipc_action_client_id);
 
     if (service) {
@@ -628,21 +600,8 @@ public:
   void
   intra_process_action_send_result_request(
     uint64_t ipc_action_client_id,
-    RequestT result_request,
-    std::function<void(std::shared_ptr<void>)> callback)
+    RequestT result_request)
   {
-    // First, lets store the client callback to be called when the
-    // server sends the result response
-    auto client = get_intra_process_action_client<ActionT>(ipc_action_client_id);
-
-    if (client) {
-      client->store_result_response_callback(callback);
-    } else {
-      // Client went out of scope
-      return;
-    }
-
-    // Now lets send the result request to the server
     auto service = get_matching_intra_process_action_server<ActionT>(ipc_action_client_id);
 
     if (service) {
@@ -658,17 +617,19 @@ public:
    *
    * \param ipc_action_client_id the id of the action client receiving the response
    * \param goal_response the action server's goal response data.
+   * \param goal_id the Goal ID.
    */
   template<typename ActionT, typename ResponseT>
   void
   intra_process_action_send_goal_response(
     uint64_t ipc_action_client_id,
-    ResponseT goal_response)
+    ResponseT goal_response,
+    size_t goal_id)
   {
     auto client = get_intra_process_action_client<ActionT>(ipc_action_client_id);
 
     if (client) {
-      client->store_ipc_action_goal_response(std::move(goal_response));
+      client->store_ipc_action_goal_response(std::move(goal_response), goal_id);
     }
   }
 
@@ -679,17 +640,19 @@ public:
    *
    * \param ipc_action_client_id the id of the action client receiving the response
    * \param cancel_response the action server's cancel response data.
+   * \param goal_id the Goal ID.
    */
   template<typename ActionT, typename ResponseT>
   void
   intra_process_action_send_cancel_response(
     uint64_t ipc_action_client_id,
-    ResponseT cancel_response)
+    ResponseT cancel_response,
+    size_t goal_id)
   {
     auto client = get_intra_process_action_client<ActionT>(ipc_action_client_id);
 
     if (client) {
-      client->store_ipc_action_cancel_response(std::move(cancel_response));
+      client->store_ipc_action_cancel_response(std::move(cancel_response), goal_id);
     }
   }
 
@@ -700,17 +663,19 @@ public:
    *
    * \param ipc_action_client_id the id of the action client receiving the response
    * \param result_response the action server's result response data.
+   * \param goal_id the Goal ID.
    */
   template<typename ActionT, typename ResponseT>
   void
   intra_process_action_send_result_response(
     uint64_t ipc_action_client_id,
-    ResponseT result_response)
+    ResponseT result_response,
+    size_t goal_id)
   {
     auto client = get_intra_process_action_client<ActionT>(ipc_action_client_id);
 
     if (client) {
-      client->store_ipc_action_result_response(std::move(result_response));
+      client->store_ipc_action_result_response(std::move(result_response), goal_id);
     }
   }
 

--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -93,7 +93,11 @@ ClientBase::take_type_erased_response(void * response_out, rmw_request_id_t & re
     &request_header_out,
     response_out);
   if (RCL_RET_CLIENT_TAKE_FAILED == ret) {
-    RCLCPP_ERROR(
+    // Currently all clients with same service name will get the server reponse.
+    // This impacts performances, since the service response is deserialized and
+    // discarded by clients receiving unwanted responses.
+    // If the response wasn't intended for a client, we log the warning below.
+    RCLCPP_WARN(
       rclcpp::get_logger("rclcpp"),
       "Error in take_type_erased_response: RCL_RET_CLIENT_TAKE_FAILED. "
       "Service name: %s", get_service_name());

--- a/rclcpp/src/rclcpp/intra_process_manager.cpp
+++ b/rclcpp/src/rclcpp/intra_process_manager.cpp
@@ -230,8 +230,11 @@ IntraProcessManager::get_action_client_id_from_goal_uuid(size_t uuid)
   auto iter = clients_uuid_to_id_.find(uuid);
 
   if (iter == clients_uuid_to_id_.end()) {
-    throw std::runtime_error(
-            "No ipc action clients stored with this UUID.");
+    RCLCPP_WARN(
+      rclcpp::get_logger("rclcpp"),
+      "No action clients match the specified goal UUID: %ld", uuid);
+
+    return 0;
   }
 
   return iter->second;
@@ -438,6 +441,9 @@ IntraProcessManager::get_action_client_intra_process(
 
   auto client_it = action_clients_.find(intra_process_action_client_id);
   if (client_it == action_clients_.end()) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("rclcpp"),
+      "No action clients match the specified ID: %ld", intra_process_action_client_id);
     return nullptr;
   } else {
     auto client = client_it->second.lock();
@@ -445,6 +451,9 @@ IntraProcessManager::get_action_client_intra_process(
       return client;
     } else {
       action_clients_.erase(client_it);
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "Action client out of scope. ID: %ld", intra_process_action_client_id);
       return nullptr;
     }
   }

--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -939,12 +939,13 @@ private:
     }
 
     rcl_action_client_depth_t qos_history;
-    qos_history.goal_service_depth = options.goal_service_qos.history;
-    qos_history.result_service_depth = options.result_service_qos.history;
-    qos_history.cancel_service_depth = options.cancel_service_qos.history;
-    qos_history.feedback_topic_depth = options.feedback_topic_qos.history;
-    qos_history.status_topic_depth = options.status_topic_qos.history;
+    qos_history.goal_service_depth = options.goal_service_qos.depth;
+    qos_history.result_service_depth = options.result_service_qos.depth;
+    qos_history.cancel_service_depth = options.cancel_service_qos.depth;
+    qos_history.feedback_topic_depth = options.feedback_topic_qos.depth;
+    qos_history.status_topic_depth = options.status_topic_qos.depth;
 
+    // Get full action name, including namespaces.
     std::string remapped_action_name = node_base->resolve_topic_or_service_name(action_name, true);
 
     // Create a ActionClientIntraProcess which will be given

--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -464,10 +464,11 @@ public:
     auto goal_request = std::make_shared<GoalRequest>();
     goal_request->goal_id.uuid = this->generate_goal_id();
     goal_request->goal = goal;
+    size_t hashed_guuid = std::hash<GoalUUID>()(goal_request->goal_id.uuid);
 
     // The callback to be called when server accepts the goal, using the server
     // response as argument.
-    auto callback =
+    auto goal_accepted_callback =
       [this, goal_request, options, promise](std::shared_ptr<void> response) mutable
       {
         using GoalResponse = typename ActionT::Impl::SendGoalService::Response;
@@ -515,10 +516,12 @@ public:
       // If there's not, we fall back into inter-process communication, since
       // the server might be available in another process or was configured to not use IPC.
       if (intra_process_server_available) {
+        ipc_action_client_->store_goal_response_callback(hashed_guuid, goal_accepted_callback);
+
         ipm->intra_process_action_send_goal_request<ActionT>(
           ipc_action_client_id_,
-          std::move(goal_request),
-          callback);
+          std::move(goal_request));
+
         intra_process_send_done = true;
       }
     }
@@ -527,29 +530,38 @@ public:
       // Send inter-process goal request
       this->send_goal_request(
         std::static_pointer_cast<void>(goal_request),
-        callback);
+        goal_accepted_callback);
     }
 
-    // TODO(jacobperron): Encapsulate into it's own function and
-    //                    consider exposing an option to disable this cleanup
-    // To prevent the list from growing out of control, forget about any goals
-    // with no more user references
-    {
-      std::lock_guard<std::mutex> guard(goal_handles_mutex_);
-      auto goal_handle_it = goal_handles_.begin();
-      while (goal_handle_it != goal_handles_.end()) {
-        if (!goal_handle_it->second.lock()) {
-          RCLCPP_DEBUG(
-            this->get_logger(),
-            "Dropping weak reference to goal handle during send_goal()");
-          goal_handle_it = goal_handles_.erase(goal_handle_it);
-        } else {
-          ++goal_handle_it;
-        }
-      }
-    }
+    clear_expired_goals();
 
     return future;
+  }
+
+  void
+  clear_expired_goals()
+  // TODO(jacobperron): Consider exposing an option to disable this cleanup
+  // To prevent the list from growing out of control, forget about any goals
+  // with no more user references
+  {
+    std::lock_guard<std::mutex> guard(goal_handles_mutex_);
+    auto goal_handle_it = goal_handles_.begin();
+    while (goal_handle_it != goal_handles_.end()) {
+      if (!goal_handle_it->second.lock()) {
+        RCLCPP_DEBUG(
+          this->get_logger(),
+          "Dropping weak reference to goal handle during send_goal()");
+        goal_handle_it = goal_handles_.erase(goal_handle_it);
+
+        size_t hashed_guuid = std::hash<GoalUUID>()(goal_handle_it->first);
+
+        if (use_intra_process_) {
+          ipc_action_client_->clear_expired_goals(hashed_guuid);
+        }
+      } else {
+        ++goal_handle_it;
+      }
+    }
   }
 
   /// Asynchronously get the result for an active goal.
@@ -794,7 +806,8 @@ private:
 
     // The client callback to be called when server calculates the result, using the server
     // response as argument.
-    auto callback =
+    // The response is set on ServerGoalHandle succeed, abort or canceled
+    auto result_response_callback =
       [goal_handle, this](std::shared_ptr<void> response) mutable
       {
         // Wrap the response in a struct with the fields a user cares about
@@ -828,10 +841,13 @@ private:
         // If there's not, we fall back into inter-process communication, since
         // the server might be available in another process or was configured to not use IPC.
         if (intra_process_server_available) {
+          size_t hashed_guuid = std::hash<GoalUUID>()(goal_handle->get_goal_id());
+          ipc_action_client_->store_result_response_callback(hashed_guuid, result_response_callback);
+
           ipm->intra_process_action_send_result_request<ActionT>(
             ipc_action_client_id_,
-            std::move(goal_result_request),
-            callback);
+            std::move(goal_result_request));
+
           intra_process_send_done = true;
         }
       }
@@ -840,7 +856,7 @@ private:
         // Send inter-process result request
         this->send_result_request(
           std::static_pointer_cast<void>(goal_result_request),
-          callback);
+          result_response_callback);
       }
     } catch (rclcpp::exceptions::RCLError & ex) {
       // This will cause an exception when the user tries to access the result
@@ -858,7 +874,7 @@ private:
     auto promise = std::make_shared<std::promise<typename CancelResponse::SharedPtr>>();
     std::shared_future<typename CancelResponse::SharedPtr> future(promise->get_future());
 
-    auto callback =
+    auto server_cancel_callback =
       [cancel_callback, promise](std::shared_ptr<void> response) mutable
       {
         auto cancel_response = std::static_pointer_cast<CancelResponse>(response);
@@ -884,10 +900,13 @@ private:
       // If there's not, we fall back into inter-process communication, since
       // the server might be available in another process or was configured to not use IPC.
       if (intra_process_server_available) {
+        size_t hashed_guuid = std::hash<GoalUUID>()(cancel_request->goal_info.goal_id.uuid);
+        ipc_action_client_->store_cancel_goal_callback(hashed_guuid, server_cancel_callback);
+
         ipm->intra_process_action_send_cancel_request<ActionT>(
           ipc_action_client_id_,
-          std::move(cancel_request),
-          callback);
+          std::move(cancel_request));
+
         intra_process_send_done = true;
       }
     }
@@ -895,7 +914,7 @@ private:
     if (!intra_process_send_done) {
       this->send_cancel_request(
         std::static_pointer_cast<void>(cancel_request),
-        callback);
+        server_cancel_callback);
     }
     return future;
   }

--- a/rclcpp_action/include/rclcpp_action/server.hpp
+++ b/rclcpp_action/include/rclcpp_action/server.hpp
@@ -677,6 +677,10 @@ protected:
           uint64_t ipc_action_client_id =
             ipm->get_action_client_id_from_goal_uuid(hashed_uuid);
 
+          if (!ipc_action_client_id) {
+            return;
+          }
+
           auto typed_response = std::static_pointer_cast<ResultResponse>(result_message);
           ipm->template intra_process_action_send_result_response<ActionT>(
             ipc_action_client_id,

--- a/rclcpp_action/include/rclcpp_action/server.hpp
+++ b/rclcpp_action/include/rclcpp_action/server.hpp
@@ -925,9 +925,9 @@ private:
     }
 
     rcl_action_server_depth_t qos_history;
-    qos_history.goal_service_depth = options.goal_service_qos.history;
-    qos_history.result_service_depth = options.result_service_qos.history;
-    qos_history.cancel_service_depth = options.cancel_service_qos.history;
+    qos_history.goal_service_depth = options.goal_service_qos.depth;
+    qos_history.result_service_depth = options.result_service_qos.depth;
+    qos_history.cancel_service_depth = options.cancel_service_qos.depth;
 
     std::lock_guard<std::recursive_mutex> lock(ipc_mutex_);
 

--- a/rclcpp_action/include/rclcpp_action/types.hpp
+++ b/rclcpp_action/include/rclcpp_action/types.hpp
@@ -69,14 +69,13 @@ struct hash<rclcpp_action::GoalUUID>
 {
   size_t operator()(const rclcpp_action::GoalUUID & uuid) const noexcept
   {
-    // TODO(sloretz) Use someone else's hash function and cite it
-    size_t result = 0;
-    for (size_t i = 0; i < uuid.size(); ++i) {
-      for (size_t b = 0; b < sizeof(size_t); ++b) {
-        size_t part = uuid[i];
-        part <<= CHAR_BIT * b;
-        result ^= part;
-      }
+    // using the FNV-1a hash algorithm
+    constexpr size_t FNV_prime = 1099511628211u;
+    size_t result = 14695981039346656037u;
+
+    for (const auto& byte : uuid) {
+      result ^= byte;
+      result *= FNV_prime;
     }
     return result;
   }


### PR DESCRIPTION
dd866e0f Change RCL_RET_CLIENT_TAKE_FAILED from ERROR to RCLCPP_WARN
09bb87ea Don't throw in a normal situation of expired IPC Action client
b07efd87 Check if data in buffers before extract
dda04a18 Fix IPC Actions QoS depth
23ca64aa Fix data race on IPC Actions callbacks
40266b88 Correct intra-process actions is_ready()
94737b3 Use Goal ID as key to store client callbacks and responses from server
da1b530 Use the FNV-1a hash algorithm for Goal UUID
