### PR TITLE
Allow for deferred responses with ipc

### DIFF
--- a/rclcpp/include/rclcpp/create_service.hpp
+++ b/rclcpp/include/rclcpp/create_service.hpp
@@ -48,7 +48,8 @@ create_service(
 
   auto serv = Service<ServiceT>::make_shared(
     node_base,
-    service_name, any_service_callback, service_options, ipc_setting);
+    service_name, any_service_callback, service_options);
+  serv->post_init_setup(node_base, ipc_setting);
   auto serv_base_ptr = std::dynamic_pointer_cast<ServiceBase>(serv);
   node_services->add_service(serv_base_ptr, group);
   return serv;

--- a/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
@@ -69,13 +69,15 @@ public:
   using RequestCallbackPair = std::pair<SharedRequest, CallbackInfoVariant>;
   using ClientIDtoRequest = std::pair<uint64_t, RequestCallbackPair>;
 
+  using GetServiceHandle = std::function<std::shared_ptr<rclcpp::Service<ServiceT>> ()>;
+
   ServiceIntraProcess(
-    std::shared_ptr<rclcpp::Service<ServiceT>> service_handle,
+    GetServiceHandle get_service_handle_fcn,
     AnyServiceCallback<ServiceT> callback,
     rclcpp::Context::SharedPtr context,
     const std::string & service_name,
     const rclcpp::QoS & qos_profile)
-  : ServiceIntraProcessBase(context, service_name, qos_profile), any_callback_(callback), service_handle_(service_handle)
+  : ServiceIntraProcessBase(context, service_name, qos_profile), any_callback_(callback), get_service_handle_fcn_(get_service_handle_fcn)
   {
     // Create the intra-process buffer.
     buffer_ = rclcpp::experimental::create_service_intra_process_buffer<
@@ -151,7 +153,8 @@ public:
     auto req_id = std::make_shared<rmw_request_id_t>();
     req_id->sequence_number = intra_process_client_id;
 
-    SharedResponse response = any_callback_.dispatch(service_handle_, req_id, std::move(typed_request));
+    auto service_handle = get_service_handle_fcn_();
+    SharedResponse response = any_callback_.dispatch(service_handle, req_id, std::move(typed_request));
 
     if (response) {
       send_response(intra_process_client_id, response);
@@ -167,7 +170,7 @@ protected:
 
   AnyServiceCallback<ServiceT> any_callback_;
 
-  std::shared_ptr<rclcpp::Service<ServiceT>> service_handle_;
+  GetServiceHandle get_service_handle_fcn_ {nullptr};
 
   std::unordered_map<uint64_t, std::reference_wrapper<CallbackInfoVariant>> callback_info_;
 };

--- a/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
@@ -70,11 +70,12 @@ public:
   using ClientIDtoRequest = std::pair<uint64_t, RequestCallbackPair>;
 
   ServiceIntraProcess(
+    std::shared_ptr<rclcpp::Service<ServiceT>> service_handle,
     AnyServiceCallback<ServiceT> callback,
     rclcpp::Context::SharedPtr context,
     const std::string & service_name,
     const rclcpp::QoS & qos_profile)
-  : ServiceIntraProcessBase(context, service_name, qos_profile), any_callback_(callback)
+  : ServiceIntraProcessBase(context, service_name, qos_profile), any_callback_(callback), service_handle_(service_handle)
   {
     // Create the intra-process buffer.
     buffer_ = rclcpp::experimental::create_service_intra_process_buffer<
@@ -115,32 +116,42 @@ public:
     SharedRequest & typed_request = ptr->second.first;
     CallbackInfoVariant & value = ptr->second.second;
 
-    SharedResponse response = any_callback_.dispatch(nullptr, nullptr, std::move(typed_request));
+    // To allow for the user callback to handle deferred responses for IPC in an ambiguous way,
+    // we are overloading the rmw_request_id semantics to provide the intra process client ID.
+    auto req_id = std::make_shared<rmw_request_id_t>();
+    req_id->sequence_number = intra_process_client_id;
+
+    SharedResponse response = any_callback_.dispatch(service_handle_, req_id, std::move(typed_request));
 
     if (response) {
-      std::unique_lock<std::recursive_mutex> lock(reentrant_mutex_);
+      send_response(intra_process_client_id, response);
+    }
+  }
 
-      auto client_it = clients_.find(intra_process_client_id);
+  void send_response(uint64_t & intra_process_client_id, SharedResponse & response)
+  {
+    std::unique_lock<std::recursive_mutex> lock(reentrant_mutex_);
 
-      if (client_it == clients_.end()) {
-        RCLCPP_WARN(
-          rclcpp::get_logger("rclcpp"),
-          "Calling intra_process_service_send_response for invalid or no "
-          "longer existing client id");
-        return;
-      }
+    auto client_it = clients_.find(intra_process_client_id);
 
-      auto client_intra_process_base = client_it->second.lock();
+    if (client_it == clients_.end()) {
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "Calling intra_process_service_send_response for invalid or no "
+        "longer existing client id");
+      return;
+    }
 
-      if (client_intra_process_base) {
-        auto client = std::dynamic_pointer_cast<
-          rclcpp::experimental::ClientIntraProcess<ServiceT>>(
-          client_intra_process_base);
-        client->store_intra_process_response(
-          std::make_pair(std::move(response), std::move(value)));
-      } else {
-        clients_.erase(client_it);
-      }
+    auto client_intra_process_base = client_it->second.lock();
+
+    if (client_intra_process_base) {
+      auto client = std::dynamic_pointer_cast<
+        rclcpp::experimental::ClientIntraProcess<ServiceT>>(
+        client_intra_process_base);
+      client->store_intra_process_response(
+        std::make_pair(std::move(response), std::move(value)));
+    } else {
+      clients_.erase(client_it);
     }
   }
 
@@ -152,6 +163,8 @@ protected:
   BufferUniquePtr buffer_;
 
   AnyServiceCallback<ServiceT> any_callback_;
+
+  std::shared_ptr<rclcpp::Service<ServiceT>> service_handle_;
 };
 
 }  // namespace experimental

--- a/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
@@ -172,7 +172,7 @@ protected:
 
   GetServiceHandle get_service_handle_fcn_ {nullptr};
 
-  std::unordered_map<uint64_t, std::reference_wrapper<CallbackInfoVariant>> callback_info_;
+  std::unordered_map<uint64_t, CallbackInfoVariant> callback_info_;
 };
 
 }  // namespace experimental

--- a/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
@@ -179,6 +179,8 @@ protected:
 
   std::weak_ptr<rclcpp::Service<ServiceT>> service_handle_;
 
+  // Store callback variants in a map to support deferred response
+  // access by intra-process client id.
   std::unordered_map<uint64_t, CallbackInfoVariant> callback_info_;
 };
 

--- a/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
@@ -146,7 +146,8 @@ public:
 
     uint64_t intra_process_client_id = ptr->first;
     SharedRequest & typed_request = ptr->second.first;
-    callback_info_.emplace(intra_process_client_id, ptr->second.second);
+    CallbackInfoVariant & value = ptr->second.second;
+    callback_info_.emplace(std::make_pair(intra_process_client_id, std::move(value)));
 
     // To allow for the user callback to handle deferred responses for IPC in an ambiguous way,
     // we are overloading the rmw_request_id semantics to provide the intra process client ID.

--- a/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
@@ -70,7 +70,7 @@ public:
   using ClientIDtoRequest = std::pair<uint64_t, RequestCallbackPair>;
 
   ServiceIntraProcess(
-    std::shared_ptr<rclcpp::Service<ServiceT>> service_handle,
+    std::weak_ptr<rclcpp::Service<ServiceT>> service_handle,
     AnyServiceCallback<ServiceT> callback,
     rclcpp::Context::SharedPtr context,
     const std::string & service_name,
@@ -154,7 +154,14 @@ public:
     auto req_id = std::make_shared<rmw_request_id_t>();
     req_id->sequence_number = intra_process_client_id;
 
-    SharedResponse response = any_callback_.dispatch(service_handle_, req_id, std::move(typed_request));
+    auto serv_handle = service_handle_.lock();
+
+    // Return if the service handle is no longer valid
+    if (!serv_handle) {
+      return;
+    }
+
+    SharedResponse response = any_callback_.dispatch(serv_handle, req_id, std::move(typed_request));
 
     if (response) {
       send_response(intra_process_client_id, response);
@@ -170,7 +177,7 @@ protected:
 
   AnyServiceCallback<ServiceT> any_callback_;
 
-  std::shared_ptr<rclcpp::Service<ServiceT>> service_handle_;
+  std::weak_ptr<rclcpp::Service<ServiceT>> service_handle_;
 
   std::unordered_map<uint64_t, CallbackInfoVariant> callback_info_;
 };

--- a/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
@@ -146,7 +146,7 @@ public:
 
     uint64_t intra_process_client_id = ptr->first;
     SharedRequest & typed_request = ptr->second.first;
-    callback_info_[intra_process_client_id] = ptr->second.second;
+    callback_info_.emplace(intra_process_client_id, ptr->second.second);
 
     // To allow for the user callback to handle deferred responses for IPC in an ambiguous way,
     // we are overloading the rmw_request_id semantics to provide the intra process client ID.

--- a/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
@@ -121,6 +121,8 @@ public:
         rclcpp::get_logger("rclcpp"),
         "Calling intra_process_service_send_response for invalid or no "
         "longer existing client id");
+
+      callback_info_.erase(intra_process_client_id);
       return;
     }
 

--- a/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
@@ -142,6 +142,13 @@ public:
 
   void execute(std::shared_ptr<void> & data)
   {
+    auto serv_handle = service_handle_.lock();
+
+    // Return if the service handle is no longer valid
+    if (!serv_handle) {
+      return;
+    }
+
     auto ptr = std::static_pointer_cast<ClientIDtoRequest>(data);
 
     uint64_t intra_process_client_id = ptr->first;
@@ -153,13 +160,6 @@ public:
     // we are overloading the rmw_request_id semantics to provide the intra process client ID.
     auto req_id = std::make_shared<rmw_request_id_t>();
     req_id->sequence_number = intra_process_client_id;
-
-    auto serv_handle = service_handle_.lock();
-
-    // Return if the service handle is no longer valid
-    if (!serv_handle) {
-      return;
-    }
 
     SharedResponse response = any_callback_.dispatch(serv_handle, req_id, std::move(typed_request));
 

--- a/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
@@ -110,7 +110,7 @@ public:
     return std::static_pointer_cast<void>(data);
   }
 
-  void send_response(uint64_t & intra_process_client_id, SharedResponse & response)
+  void send_response(uint64_t intra_process_client_id, SharedResponse & response)
   {
     std::unique_lock<std::recursive_mutex> lock(reentrant_mutex_);
 

--- a/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
@@ -69,15 +69,13 @@ public:
   using RequestCallbackPair = std::pair<SharedRequest, CallbackInfoVariant>;
   using ClientIDtoRequest = std::pair<uint64_t, RequestCallbackPair>;
 
-  using GetServiceHandle = std::function<std::shared_ptr<rclcpp::Service<ServiceT>> ()>;
-
   ServiceIntraProcess(
-    GetServiceHandle get_service_handle_fcn,
+    std::shared_ptr<rclcpp::Service<ServiceT>> service_handle,
     AnyServiceCallback<ServiceT> callback,
     rclcpp::Context::SharedPtr context,
     const std::string & service_name,
     const rclcpp::QoS & qos_profile)
-  : ServiceIntraProcessBase(context, service_name, qos_profile), any_callback_(callback), get_service_handle_fcn_(get_service_handle_fcn)
+  : ServiceIntraProcessBase(context, service_name, qos_profile), any_callback_(callback), service_handle_(service_handle)
   {
     // Create the intra-process buffer.
     buffer_ = rclcpp::experimental::create_service_intra_process_buffer<
@@ -156,8 +154,7 @@ public:
     auto req_id = std::make_shared<rmw_request_id_t>();
     req_id->sequence_number = intra_process_client_id;
 
-    auto service_handle = get_service_handle_fcn_();
-    SharedResponse response = any_callback_.dispatch(service_handle, req_id, std::move(typed_request));
+    SharedResponse response = any_callback_.dispatch(service_handle_, req_id, std::move(typed_request));
 
     if (response) {
       send_response(intra_process_client_id, response);
@@ -173,7 +170,7 @@ protected:
 
   AnyServiceCallback<ServiceT> any_callback_;
 
-  GetServiceHandle get_service_handle_fcn_ {nullptr};
+  std::shared_ptr<rclcpp::Service<ServiceT>> service_handle_;
 
   std::unordered_map<uint64_t, CallbackInfoVariant> callback_info_;
 };

--- a/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
@@ -108,26 +108,6 @@ public:
     return std::static_pointer_cast<void>(data);
   }
 
-  void execute(std::shared_ptr<void> & data)
-  {
-    auto ptr = std::static_pointer_cast<ClientIDtoRequest>(data);
-
-    uint64_t intra_process_client_id = ptr->first;
-    SharedRequest & typed_request = ptr->second.first;
-    CallbackInfoVariant & value = ptr->second.second;
-
-    // To allow for the user callback to handle deferred responses for IPC in an ambiguous way,
-    // we are overloading the rmw_request_id semantics to provide the intra process client ID.
-    auto req_id = std::make_shared<rmw_request_id_t>();
-    req_id->sequence_number = intra_process_client_id;
-
-    SharedResponse response = any_callback_.dispatch(service_handle_, req_id, std::move(typed_request));
-
-    if (response) {
-      send_response(intra_process_client_id, response);
-    }
-  }
-
   void send_response(uint64_t & intra_process_client_id, SharedResponse & response)
   {
     std::unique_lock<std::recursive_mutex> lock(reentrant_mutex_);
@@ -148,10 +128,33 @@ public:
       auto client = std::dynamic_pointer_cast<
         rclcpp::experimental::ClientIntraProcess<ServiceT>>(
         client_intra_process_base);
+      CallbackInfoVariant & value = callback_info_[intra_process_client_id];
       client->store_intra_process_response(
         std::make_pair(std::move(response), std::move(value)));
     } else {
       clients_.erase(client_it);
+    }
+
+    callback_info_.erase(intra_process_client_id);
+  }
+
+  void execute(std::shared_ptr<void> & data)
+  {
+    auto ptr = std::static_pointer_cast<ClientIDtoRequest>(data);
+
+    uint64_t intra_process_client_id = ptr->first;
+    SharedRequest & typed_request = ptr->second.first;
+    callback_info_[intra_process_client_id] = std::ref(ptr->second.second);
+
+    // To allow for the user callback to handle deferred responses for IPC in an ambiguous way,
+    // we are overloading the rmw_request_id semantics to provide the intra process client ID.
+    auto req_id = std::make_shared<rmw_request_id_t>();
+    req_id->sequence_number = intra_process_client_id;
+
+    SharedResponse response = any_callback_.dispatch(service_handle_, req_id, std::move(typed_request));
+
+    if (response) {
+      send_response(intra_process_client_id, response);
     }
   }
 
@@ -165,6 +168,8 @@ protected:
   AnyServiceCallback<ServiceT> any_callback_;
 
   std::shared_ptr<rclcpp::Service<ServiceT>> service_handle_;
+
+  std::unordered_map<uint64_t, std::reference_wrapper<CallbackInfoVariant>> callback_info_;
 };
 
 }  // namespace experimental

--- a/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
@@ -146,7 +146,7 @@ public:
 
     uint64_t intra_process_client_id = ptr->first;
     SharedRequest & typed_request = ptr->second.first;
-    callback_info_[intra_process_client_id] = std::ref(ptr->second.second);
+    callback_info_[intra_process_client_id] = ptr->second.second;
 
     // To allow for the user callback to handle deferred responses for IPC in an ambiguous way,
     // we are overloading the rmw_request_id semantics to provide the intra process client ID.

--- a/rclcpp/include/rclcpp/experimental/service_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/service_intra_process_base.hpp
@@ -96,9 +96,6 @@ public:
     rclcpp::experimental::ClientIntraProcessBase::SharedPtr client,
     uint64_t client_id);
 
-  // RCLCPP_PUBLIC
-  // void send_response(uint64_t & intra_process_client_id, 1tti & response) = 0;
-
   /// Set a callback to be called when each new request arrives.
   /**
    * The callback receives a size_t which is the number of requests received

--- a/rclcpp/include/rclcpp/experimental/service_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/service_intra_process_base.hpp
@@ -96,6 +96,9 @@ public:
     rclcpp::experimental::ClientIntraProcessBase::SharedPtr client,
     uint64_t client_id);
 
+  RCLCPP_PUBLIC
+  void send_response(uint64_t & intra_process_client_id, SharedResponse & response) = 0;
+
   /// Set a callback to be called when each new request arrives.
   /**
    * The callback receives a size_t which is the number of requests received

--- a/rclcpp/include/rclcpp/experimental/service_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/service_intra_process_base.hpp
@@ -96,8 +96,8 @@ public:
     rclcpp::experimental::ClientIntraProcessBase::SharedPtr client,
     uint64_t client_id);
 
-  RCLCPP_PUBLIC
-  void send_response(uint64_t & intra_process_client_id, SharedResponse & response) = 0;
+  // RCLCPP_PUBLIC
+  // void send_response(uint64_t & intra_process_client_id, 1tti & response) = 0;
 
   /// Set a callback to be called when each new request arrives.
   /**

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -561,8 +561,9 @@ public:
   {
     if (use_intra_process_)
     {
+      auto intra_response = std::make_shared<ServiceT::Response>(response);
       // The sequence number here is used as a proxy for the intra-process client ID
-      service_intra_process_->send_response(req_id.sequence_number, response);
+      service_intra_process_->send_response(req_id.sequence_number, intra_response);
       return;
     }
 

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -550,6 +550,12 @@ public:
     }
   }
 
+  std::shared_ptr<Service<ServiceT>>
+  get_handle()
+  {
+    return shared_from_this();
+  }
+
   void
   send_response(rmw_request_id_t & req_id, typename ServiceT::Response & response)
   {
@@ -598,6 +604,7 @@ public:
     using ServiceIntraProcessT = rclcpp::experimental::ServiceIntraProcess<ServiceT>;
 
     service_intra_process_ = std::make_shared<ServiceIntraProcessT>(
+      std::bind(&Service::get_handle, this),
       any_callback_,
       context_,
       this->get_service_name(),

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -556,7 +556,7 @@ public:
     if (use_intra_process_)
     {
       // The sequence number here is used as a proxy for the intra-process client ID
-      service_intra_process->send_response(req_id.sequence_number, response);
+      service_intra_process_->send_response(req_id.sequence_number, response);
       return;
     }
 

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -556,7 +556,7 @@ public:
     if (use_intra_process_)
     {
       // The sequence number here is used as a proxy for the intra-process client ID
-      service_intra_process->(req_id.sequence_number, response);
+      service_intra_process->send_response(req_id.sequence_number, response);
       return;
     }
 

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -290,8 +290,6 @@ protected:
     uint64_t intra_process_service_id,
     IntraProcessManagerWeakPtr weak_ipm);
 
-  // std::shared_ptr<rclcpp::experimental::ServiceIntraProcessBase> service_intra_process_;
-
   std::shared_ptr<rcl_node_t> node_handle_;
   std::shared_ptr<rclcpp::Context> context_;
 

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -561,7 +561,7 @@ public:
   {
     if (use_intra_process_)
     {
-      auto intra_response = std::make_shared<ServiceT::Response>(response);
+      auto intra_response = std::make_shared<typename ServiceT::Response>(response);
       // The sequence number here is used as a proxy for the intra-process client ID
       service_intra_process_->send_response(req_id.sequence_number, intra_response);
       return;

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -553,6 +553,13 @@ public:
   void
   send_response(rmw_request_id_t & req_id, typename ServiceT::Response & response)
   {
+    if (use_intra_process_)
+    {
+      // The sequence number here is used as a proxy for the intra-process client ID
+      service_intra_process->(req_id.sequence_number, response);
+      return;
+    }
+
     rcl_ret_t ret = rcl_send_response(get_service_handle().get(), &req_id, &response);
 
     if (ret == RCL_RET_TIMEOUT) {

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -459,7 +459,7 @@ public:
     rcl_service_t * service_handle,
     AnyServiceCallback<ServiceT> any_callback)
   : ServiceBase(node_base),
-    any_callback_(any_callback),
+    any_callback_(any_callback)
   {
     // check if service handle was initialized
     if (!rcl_service_is_valid(service_handle)) {

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -341,14 +341,12 @@ public:
    * \param[in] service_name Name of the topic to publish to.
    * \param[in] any_callback User defined callback to call when a client request is received.
    * \param[in] service_options options for the subscription.
-   * \param[in] ipc_setting Intra-process communication setting for the service.
    */
   Service(
     std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> node_base,
     const std::string & service_name,
     AnyServiceCallback<ServiceT> any_callback,
-    rcl_service_options_t & service_options,
-    rclcpp::IntraProcessSetting ipc_setting = rclcpp::IntraProcessSetting::NodeDefault)
+    rcl_service_options_t & service_options)
   : ServiceBase(node_base), any_callback_(any_callback)
   {
     using rosidl_typesupport_cpp::get_service_type_support_handle;
@@ -396,7 +394,14 @@ public:
 #ifndef TRACETOOLS_DISABLED
     any_callback_.register_callback_for_tracing();
 #endif
+    // Setup continues in the post construction method, post_init_setup().
+  }
 
+  /// Called post construction, so that construction may continue after shared_from_this() works.
+  void post_init_setup(
+    std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> node_base,
+    rclcpp::IntraProcessSetting ipc_setting = rclcpp::IntraProcessSetting::NodeDefault)
+  {
     // Setup intra process if requested.
     if (rclcpp::detail::resolve_use_intra_process(ipc_setting, *node_base)) {
       create_intra_process_service();
@@ -412,13 +417,11 @@ public:
    * \param[in] node_handle NodeBaseInterface pointer that is used in part of the setup.
    * \param[in] service_handle service handle.
    * \param[in] any_callback User defined callback to call when a client request is received.
-   * \param[in] ipc_setting Intra-process communication setting for the service.
    */
   Service(
     std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> node_base,
     std::shared_ptr<rcl_service_t> service_handle,
-    AnyServiceCallback<ServiceT> any_callback,
-    rclcpp::IntraProcessSetting ipc_setting = rclcpp::IntraProcessSetting::NodeDefault)
+    AnyServiceCallback<ServiceT> any_callback)
   : ServiceBase(node_base),
     any_callback_(any_callback)
   {
@@ -438,11 +441,7 @@ public:
 #ifndef TRACETOOLS_DISABLED
     any_callback_.register_callback_for_tracing();
 #endif
-
-    // Setup intra process if requested.
-    if (rclcpp::detail::resolve_use_intra_process(ipc_setting, *node_base)) {
-      create_intra_process_service();
-    }
+    // Setup continues in the post construction method, post_init_setup().
   }
 
   /// Default constructor.
@@ -454,15 +453,13 @@ public:
    * \param[in] node_handle NodeBaseInterface pointer that is used in part of the setup.
    * \param[in] service_handle service handle.
    * \param[in] any_callback User defined callback to call when a client request is received.
-   * \param[in] ipc_setting Intra-process communication setting for the service.
    */
   Service(
     std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> node_base,
     rcl_service_t * service_handle,
-    AnyServiceCallback<ServiceT> any_callback,
-    rclcpp::IntraProcessSetting ipc_setting = rclcpp::IntraProcessSetting::NodeDefault)
+    AnyServiceCallback<ServiceT> any_callback)
   : ServiceBase(node_base),
-    any_callback_(any_callback)
+    any_callback_(any_callback),
   {
     // check if service handle was initialized
     if (!rcl_service_is_valid(service_handle)) {
@@ -482,10 +479,7 @@ public:
 #ifndef TRACETOOLS_DISABLED
     any_callback_.register_callback_for_tracing();
 #endif
-    // Setup intra process if requested.
-    if (rclcpp::detail::resolve_use_intra_process(ipc_setting, *node_base)) {
-      create_intra_process_service();
-    }
+    // Setup continues in the post construction method, post_init_setup().
   }
 
   Service() = delete;
@@ -548,12 +542,6 @@ public:
     }
   }
 
-  std::shared_ptr<Service<ServiceT>>
-  get_handle()
-  {
-    return this->shared_from_this();
-  }
-
   void
   send_response(rmw_request_id_t & req_id, typename ServiceT::Response & response)
   {
@@ -603,7 +591,7 @@ public:
     using ServiceIntraProcessT = rclcpp::experimental::ServiceIntraProcess<ServiceT>;
 
     service_intra_process_ = std::make_shared<ServiceIntraProcessT>(
-      std::bind(&Service::get_handle, this),
+      this->shared_from_this(),
       any_callback_,
       context_,
       this->get_service_name(),

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -607,6 +607,10 @@ private:
   RCLCPP_DISABLE_COPY(Service)
 
   AnyServiceCallback<ServiceT> any_callback_;
+
+  // In order to mirror the send_response signature with a SharedResponse
+  // of the appropriate ServiceT type, the template class is stored
+  // as opposed to the base class which has no knowledge of ServiceT.
   std::shared_ptr<rclcpp::experimental::ServiceIntraProcess<ServiceT>> service_intra_process_;
 
 };

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -290,7 +290,7 @@ protected:
     uint64_t intra_process_service_id,
     IntraProcessManagerWeakPtr weak_ipm);
 
-  std::shared_ptr<rclcpp::experimental::ServiceIntraProcessBase> service_intra_process_;
+  // std::shared_ptr<rclcpp::experimental::ServiceIntraProcessBase> service_intra_process_;
 
   std::shared_ptr<rcl_node_t> node_handle_;
   std::shared_ptr<rclcpp::Context> context_;
@@ -553,7 +553,7 @@ public:
   std::shared_ptr<Service<ServiceT>>
   get_handle()
   {
-    return shared_from_this();
+    return this->shared_from_this();
   }
 
   void
@@ -620,6 +620,8 @@ private:
   RCLCPP_DISABLE_COPY(Service)
 
   AnyServiceCallback<ServiceT> any_callback_;
+  std::shared_ptr<rclcpp::experimental::ServiceIntraProcess<ServiceT>> service_intra_process_;
+
 };
 
 }  // namespace rclcpp

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.cpp
@@ -127,8 +127,8 @@ LifecycleNode::LifecycleNodeInterfaceImpl::init(bool enable_communication_interf
       srv_change_state_ = std::make_shared<rclcpp::Service<ChangeStateSrv>>(
         node_base_interface_,
         &state_machine_.com_interface.srv_change_state,
-        any_cb,
-        ipc_setting);
+        any_cb);
+      srv_change_state_->post_init_setup(node_base_interface_, ipc_setting);
       node_services_interface_->add_service(
         std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_change_state_),
         nullptr);
@@ -144,8 +144,8 @@ LifecycleNode::LifecycleNodeInterfaceImpl::init(bool enable_communication_interf
       srv_get_state_ = std::make_shared<rclcpp::Service<GetStateSrv>>(
         node_base_interface_,
         &state_machine_.com_interface.srv_get_state,
-        any_cb,
-        ipc_setting);
+        any_cb);
+      srv_get_state_->post_init_setup(node_base_interface_, ipc_setting);
       node_services_interface_->add_service(
         std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_state_),
         nullptr);
@@ -161,8 +161,8 @@ LifecycleNode::LifecycleNodeInterfaceImpl::init(bool enable_communication_interf
       srv_get_available_states_ = std::make_shared<rclcpp::Service<GetAvailableStatesSrv>>(
         node_base_interface_,
         &state_machine_.com_interface.srv_get_available_states,
-        any_cb,
-        ipc_setting);
+        any_cb);
+      srv_get_available_states_->post_init_setup(node_base_interface_, ipc_setting);
       node_services_interface_->add_service(
         std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_available_states_),
         nullptr);
@@ -179,8 +179,8 @@ LifecycleNode::LifecycleNodeInterfaceImpl::init(bool enable_communication_interf
         std::make_shared<rclcpp::Service<GetAvailableTransitionsSrv>>(
         node_base_interface_,
         &state_machine_.com_interface.srv_get_available_transitions,
-        any_cb,
-        ipc_setting);
+        any_cb);
+      srv_get_available_transitions_->post_init_setup(node_base_interface_, ipc_setting);
       node_services_interface_->add_service(
         std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_available_transitions_),
         nullptr);
@@ -197,8 +197,8 @@ LifecycleNode::LifecycleNodeInterfaceImpl::init(bool enable_communication_interf
         std::make_shared<rclcpp::Service<GetAvailableTransitionsSrv>>(
         node_base_interface_,
         &state_machine_.com_interface.srv_get_transition_graph,
-        any_cb,
-        ipc_setting);
+        any_cb);
+      srv_get_transition_graph_->post_init_setup(node_base_interface_, ipc_setting);
       node_services_interface_->add_service(
         std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_transition_graph_),
         nullptr);


### PR DESCRIPTION
This PR makes modifications to the service and service intraprocess manager to enable deferred services when using IPC.