### PR TITLE
Revert "Ignore local endpoints (#131)"

### DIFF
--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -273,7 +273,7 @@ public:
     // It's not possible to do that with an unique_ptr,
     // as do_intra_process_publish takes the ownership of the message.
     bool inter_process_publish_needed =
-      get_non_local_subscription_count() > 0;
+      get_subscription_count() > get_intra_process_subscription_count();
 
     if (inter_process_publish_needed) {
       auto shared_msg =
@@ -351,7 +351,7 @@ public:
     }
 
     bool inter_process_publish_needed =
-      get_non_local_subscription_count() > 0;
+      get_subscription_count() > get_intra_process_subscription_count();
 
     if (inter_process_publish_needed) {
       auto ros_msg_ptr = std::make_shared<ROSMessageType>();

--- a/rclcpp/include/rclcpp/publisher_base.hpp
+++ b/rclcpp/include/rclcpp/publisher_base.hpp
@@ -126,12 +126,6 @@ public:
   size_t
   get_subscription_count() const;
 
-  /// Get non local subscription count
-  /** \return The number of non local subscriptions. */
-  RCLCPP_PUBLIC
-  size_t
-  get_non_local_subscription_count() const;
-
   /// Get intraprocess subscription count
   /** \return The number of intraprocess subscriptions. */
   RCLCPP_PUBLIC

--- a/rclcpp/src/rclcpp/publisher_base.cpp
+++ b/rclcpp/src/rclcpp/publisher_base.cpp
@@ -190,31 +190,6 @@ PublisherBase::get_subscription_count() const
 }
 
 size_t
-PublisherBase::get_non_local_subscription_count() const
-{
-  size_t inter_process_non_local_subscription_count = 0;
-
-  rcl_ret_t status = rcl_publisher_get_non_local_subscription_count(
-    publisher_handle_.get(),
-    &inter_process_non_local_subscription_count);
-
-  if (RCL_RET_PUBLISHER_INVALID == status) {
-    rcl_reset_error();  /* next call will reset error message if not context */
-    if (rcl_publisher_is_valid_except_context(publisher_handle_.get())) {
-      rcl_context_t * context = rcl_publisher_get_context(publisher_handle_.get());
-      if (nullptr != context && !rcl_context_is_valid(context)) {
-        /* publisher is invalid due to context being shutdown */
-        return 0;
-      }
-    }
-  }
-  if (RCL_RET_OK != status) {
-    rclcpp::exceptions::throw_from_rcl_error(status, "failed to get get non local subscription count");
-  }
-  return inter_process_non_local_subscription_count;
-}
-
-size_t
 PublisherBase::get_intra_process_subscription_count() const
 {
   auto ipm = weak_ipm_.lock();


### PR DESCRIPTION
This reverts commit 8c423ce99b2abb6713e4fad7230ccb983c0706e9.
 
Why the revert?
- The full `get_non_local_subscription_count` API, down through `rmw_implementation`, is not implemented _in_ Cyclone DDS
- The Create3 platform runs Cyclone DDS, thus it otherwise breaks the Create3 on Humble.
- Furthermore, rclcpp will call this function with every publication, and:
    - we can't return an error, otherwise all publish calls will fail
    - we can't return 0, otherwise we will never publish to remote subscribers
    - we can't return the total subscription count, otherwise we would be essentially disabling IPC