### PR TITLE
Handle RCL_RET_UNSUPPORTED for get_non_local_sub count from cyclonedds

### DIFF
--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -272,8 +272,17 @@ public:
     // interprocess publish, resulting in lower publish-to-subscribe latency.
     // It's not possible to do that with an unique_ptr,
     // as do_intra_process_publish takes the ownership of the message.
-    bool inter_process_publish_needed =
-      get_non_local_subscription_count() > 0;
+
+    int non_local_sub_count = get_non_local_subscription_count();
+    bool inter_process_publish_needed = non_local_sub_count > 0;
+    // The non-local-subscription-count will temporarily be -1 on cyclone dds
+    // until it can be fully implemented there.
+    // If that case, fall-back to the previous methodology.
+    // See the implementation in publisher_base.cpp
+    if(non_local_sub_count < 0) {
+      inter_process_publish_needed =
+        (get_subscription_count() > get_intra_process_subscription_count());
+    }
 
     if (inter_process_publish_needed) {
       auto shared_msg =
@@ -350,8 +359,16 @@ public:
       return this->do_inter_process_publish(ros_msg);
     }
 
-    bool inter_process_publish_needed =
-      get_non_local_subscription_count() > 0;
+    int non_local_sub_count = get_non_local_subscription_count();
+    bool inter_process_publish_needed = non_local_sub_count > 0;
+    // The non-local-subscription-count will temporarily be -1 on cyclone dds
+    // until it can be fully implemented there.
+    // If that case, fall-back to the previous methodology.
+    // See the implementation in publisher_base.cpp
+    if(non_local_sub_count < 0) {
+      inter_process_publish_needed =
+        (get_subscription_count() > get_intra_process_subscription_count());
+    }
 
     if (inter_process_publish_needed) {
       auto ros_msg_ptr = std::make_shared<ROSMessageType>();

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -273,7 +273,7 @@ public:
     // It's not possible to do that with an unique_ptr,
     // as do_intra_process_publish takes the ownership of the message.
 
-    int non_local_sub_count = get_non_local_subscription_count();
+    size_t non_local_sub_count = get_non_local_subscription_count();
     bool inter_process_publish_needed = non_local_sub_count > 0;
     // The non-local-subscription-count will temporarily be -1 on cyclone dds
     // until it can be fully implemented there.
@@ -359,7 +359,7 @@ public:
       return this->do_inter_process_publish(ros_msg);
     }
 
-    int non_local_sub_count = get_non_local_subscription_count();
+    size_t non_local_sub_count = get_non_local_subscription_count();
     bool inter_process_publish_needed = non_local_sub_count > 0;
     // The non-local-subscription-count will temporarily be -1 on cyclone dds
     // until it can be fully implemented there.

--- a/rclcpp/src/rclcpp/publisher_base.cpp
+++ b/rclcpp/src/rclcpp/publisher_base.cpp
@@ -208,6 +208,14 @@ PublisherBase::get_non_local_subscription_count() const
       }
     }
   }
+
+  if (RCL_RET_UNSUPPORTED == status) {
+    // TODO: returning -1 is temporary until the API is fully implemented in Cyclone DDS
+    // https://github.com/ros2/rclcpp/issues/2202#issuecomment-1772287249
+    // minimally see: rmw_cyclonedds_cpp/src/rmw_node.cpp
+    return -1;
+  }
+
   if (RCL_RET_OK != status) {
     rclcpp::exceptions::throw_from_rcl_error(status, "failed to get get non local subscription count");
   }


### PR DESCRIPTION
This API is not fully implemented in cyclonedds.  More information:
- https://github.com/ros2/rclcpp/issues/2202#issuecomment-1772287249
- [PR to at least be graceful about it](https://github.com/irobot-ros/rmw_cyclonedds/pull/29)

Here, for the `get_non_local_subscription_count method`
- detect `RCL_RET_UNSUPPORTED` and return -1.  
- Then handle this condition in the top-level API method