### PR TITLE
Do not call get_non_local_subscription_count

### DIFF
--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -273,7 +273,7 @@ public:
     // It's not possible to do that with an unique_ptr,
     // as do_intra_process_publish takes the ownership of the message.
     bool inter_process_publish_needed =
-      get_non_local_subscription_count() > 0;
+        get_subscription_count() > get_intra_process_subscription_count();
 
     if (inter_process_publish_needed) {
       auto shared_msg =
@@ -351,7 +351,7 @@ public:
     }
 
     bool inter_process_publish_needed =
-      get_non_local_subscription_count() > 0;
+        get_subscription_count() > get_intra_process_subscription_count();
 
     if (inter_process_publish_needed) {
       auto ros_msg_ptr = std::make_shared<ROSMessageType>();


### PR DESCRIPTION
- Use the previous approach, and do not call that method (but leave it in the codebase).
- See [PR-137](https://github.com/irobot-ros/rclcpp/pull/137) for context