### PR TITLE
Remove clear request callback in service destructor

### DIFF
--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -37,8 +37,6 @@ ServiceBase::ServiceBase(
 
 ServiceBase::~ServiceBase()
 {
-  clear_on_new_request_callback();
-
   std::lock_guard<std::recursive_mutex> lock(ipc_mutex_);
   if (!use_intra_process_) {
     return;


### PR DESCRIPTION
When using lifecycle nodes, the node creates services from an rcl service handle owned by the node's rcl state machine, not the service itself. Because the EventsExecutor also clears the service callbacks manually in its destructor, there is a segfault that occurs depending on the order of destruction if the rcl/rmw service handle is destroyed underneath before the callback has been removed. 

From what I can tell, this clear is unnecessary in the service destructor. This clear is also not in the upstream rclcpp. 

I tested this change on a local unit test that adds a lifecycle node to an events executor (also a SingleThreadedExectutor) and it passes. 