### PR TITLE
Fix IPC Actions data race

### DIFF
--- a/rclcpp/include/rclcpp/experimental/action_client_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/action_client_intra_process_base.hpp
@@ -158,6 +158,17 @@ public:
     event_info_multi_map_.erase(goal_id);
   }
 
+  bool has_goal_id(size_t goal_id) const
+  {
+    // Check if the intra-process client has this goal_id
+    auto it = event_info_multi_map_.find(goal_id);
+    if (it != event_info_multi_map_.end()) {
+      return true;
+    }
+
+    return false;
+  }
+
 private:
   std::string action_name_;
   QoS qos_profile_;

--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -835,12 +835,18 @@ private:
         // the server might be available in another process or was configured to not use IPC.
         if (intra_process_server_available) {
           size_t hashed_guuid = std::hash<GoalUUID>()(goal_handle->get_goal_id());
-          ipc_action_client_->store_result_response_callback(
-            hashed_guuid, result_response_callback);
 
-          intra_process_send_done = ipm->template intra_process_action_send_result_request<ActionT>(
-              ipc_action_client_id_,
-              std::move(goal_result_request));
+          // check if this goal has been sent through intra-process
+          bool goal_sent_by_ipc = ipc_action_client_->has_goal_id(hashed_guuid);
+
+          if (goal_sent_by_ipc) {
+            ipc_action_client_->store_result_response_callback(
+              hashed_guuid, result_response_callback);
+
+            intra_process_send_done = ipm->template intra_process_action_send_result_request<ActionT>(
+                ipc_action_client_id_,
+                std::move(goal_result_request));
+          }
         }
       }
 

--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -97,6 +97,16 @@ public:
     );
   }
 
+  /// Return true if there is an intra-process action server that is ready to take goal requests.
+  bool
+  intra_process_action_server_is_available()
+  {
+    if (auto ipm = weak_ipm_.lock()) {
+      return ipm->action_server_is_available(ipc_action_client_id_);
+    }
+    return false;
+  }
+
   // -------------
   // Waitables API
 

--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -523,13 +523,17 @@ public:
       // If there's not, we fall back into inter-process communication, since
       // the server might be available in another process or was configured to not use IPC.
       if (intra_process_server_available) {
-        ipc_action_client_->store_goal_response_callback(
-          hashed_guuid, goal_response_callback);
+        bool goal_sent_by_ipc = ipc_action_client_->has_goal_id(hashed_guuid);
 
-        intra_process_send_done = ipm->template intra_process_action_send_goal_request<ActionT>(
-            ipc_action_client_id_,
-            std::move(goal_request),
-            hashed_guuid);
+        if (goal_sent_by_ipc) {
+          ipc_action_client_->store_goal_response_callback(
+            hashed_guuid, goal_response_callback);
+
+          intra_process_send_done = ipm->template intra_process_action_send_goal_request<ActionT>(
+              ipc_action_client_id_,
+              std::move(goal_request),
+              hashed_guuid);
+        }
       }
     }
 
@@ -846,7 +850,6 @@ private:
         if (intra_process_server_available) {
           size_t hashed_guuid = std::hash<GoalUUID>()(goal_handle->get_goal_id());
 
-          // check if this goal has been sent through intra-process
           bool goal_sent_by_ipc = ipc_action_client_->has_goal_id(hashed_guuid);
 
           if (goal_sent_by_ipc) {
@@ -907,12 +910,17 @@ private:
       // the server might be available in another process or was configured to not use IPC.
       if (intra_process_server_available) {
         size_t hashed_guuid = std::hash<GoalUUID>()(cancel_request->goal_info.goal_id.uuid);
-        ipc_action_client_->store_cancel_goal_callback(
-          hashed_guuid, cancel_goal_callback);
 
-        intra_process_send_done = ipm->template intra_process_action_send_cancel_request<ActionT>(
+        bool goal_sent_by_ipc = ipc_action_client_->has_goal_id(hashed_guuid);
+
+        if (goal_sent_by_ipc) {
+          ipc_action_client_->store_cancel_goal_callback(
+            hashed_guuid, cancel_goal_callback);
+
+          intra_process_send_done = ipm->template intra_process_action_send_cancel_request<ActionT>(
             ipc_action_client_id_,
             std::move(cancel_request));
+        }
       }
     }
 


### PR DESCRIPTION
The problem was a data race where the RMW Action Client/Server were discovered before their intra-process versions.

This caused communication to go through inter-process initially, but later callbacks assumed the communication went intra-process, leading to issues when the same goal was used with mixed communication modes.

To fix this, I made two changes:

* Checking if the goal was sent via inter or intra-process,thus calling the correct APIs in callbacks. This ensures consistent communication modes through goal lifetime.

* Added a public ActionClient API to check if the intra-process server is available. This allows the user to ensure communication will be intra-process if they really want, by possibly waiting for the intra-process discovery.



