### PR TITLE
Fix data race in Actions: Part 2

### DIFF
--- a/rclcpp/include/rclcpp/experimental/action_client_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/action_client_intra_process_base.hpp
@@ -158,17 +158,6 @@ public:
     event_info_multi_map_.erase(goal_id);
   }
 
-  bool has_goal_id(size_t goal_id) const
-  {
-    // Check if the intra-process client has this goal_id
-    auto it = event_info_multi_map_.find(goal_id);
-    if (it != event_info_multi_map_.end()) {
-      return true;
-    }
-
-    return false;
-  }
-
 private:
   std::string action_name_;
   QoS qos_profile_;

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -1051,7 +1051,7 @@ private:
           auto ptr = MessageAllocTraits::allocate(allocator, 1);
           MessageAllocTraits::construct(allocator, ptr, *message);
 
-          subscription->provide_intra_process_data(std::move(MessageUniquePtr(ptr, deleter)));
+          subscription->provide_intra_process_data(MessageUniquePtr(ptr, deleter));
         }
 
         continue;
@@ -1094,7 +1094,7 @@ private:
             MessageAllocTraits::construct(allocator, ptr, *message);
 
             ros_message_subscription->provide_intra_process_message(
-              std::move(MessageUniquePtr(ptr, deleter)));
+              MessageUniquePtr(ptr, deleter));
           }
         }
       }


### PR DESCRIPTION
The method used in https://github.com/irobot-ros/rclcpp/pull/147 to verify if a goal was sent through inter or intra-process, was checking if the IntraProcessClient had the GoalID stored on the reponse buffers.

This approach didn't work in all scenarios, since the GoalID could be removed from the client even if the goal is still alive (after responses were processed).

The approach in this PR is similar - it also looks for the GoalID, but in the intra-process manager which has the goal ID stored for all the lifetime of the goal. So at any moment we can determine if the goal was or not sent though IPC.

