### PR TITLE
change priority of action ready events

### DIFF
--- a/rclcpp_action/src/client.cpp
+++ b/rclcpp_action/src/client.cpp
@@ -354,6 +354,16 @@ ClientBase::is_ready(const rcl_wait_set_t & wait_set)
   }
 
   pimpl_->next_ready_event = ClientBaseImpl::NO_EVENT_READY;
+  // The following 'if' statements set the priority of execution for different entities.
+  // The order of priority for action components are:
+  //   Status > Goal Response > Result Response > Cancel Response > Feedback.
+  // Feedback has the lowest priority, since if the client spins slower than the
+  // server's feedback rate, it may never process the action results.
+  
+  if (is_status_ready) {
+    pimpl_->next_ready_event = static_cast<size_t>(EntityType::StatusSubscription);
+    return true;
+  }
 
   if (is_goal_response_ready) {
     pimpl_->next_ready_event = static_cast<size_t>(EntityType::GoalClient);
@@ -372,11 +382,6 @@ ClientBase::is_ready(const rcl_wait_set_t & wait_set)
 
   if (is_feedback_ready) {
     pimpl_->next_ready_event = static_cast<size_t>(EntityType::FeedbackSubscription);
-    return true;
-  }
-
-  if (is_status_ready) {
-    pimpl_->next_ready_event = static_cast<size_t>(EntityType::StatusSubscription);
     return true;
   }
 

--- a/rclcpp_action/test/test_client.cpp
+++ b/rclcpp_action/test/test_client.cpp
@@ -565,7 +565,7 @@ TEST_F(TestClientAgainstServer, async_send_goal_with_feedback_callback_wait_for_
 
   ASSERT_EQ(5u, wrapped_result.result->sequence.size());
   EXPECT_EQ(3, wrapped_result.result->sequence.back());
-  EXPECT_EQ(5, feedback_count);
+  EXPECT_EQ(2, feedback_count);
 }
 
 TEST_F(TestClientAgainstServer, async_send_goal_with_result_callback_wait_for_result)
@@ -1010,11 +1010,12 @@ TEST_F(TestClientAgainstServer, execute_rcl_errors)
   {
     ActionGoal goal;
     goal.order = 5;
-    auto mock = mocking_utils::patch_and_return(
-      "lib:rclcpp_action", rcl_action_take_result_response, RCL_RET_ERROR);
 
     auto future_goal_handle = action_client->async_send_goal(goal, send_goal_ops);
     dual_spin_until_future_complete(future_goal_handle);
+    auto mock = mocking_utils::patch_and_return(
+      "lib:rclcpp_action", rcl_action_take_result_response, RCL_RET_ERROR);
+
     auto goal_handle = future_goal_handle.get();
     auto future_result = action_client->async_get_result(goal_handle);
     EXPECT_THROW(


### PR DESCRIPTION
See https://github.com/ros2/rclcpp/pull/2612 for more info. Applying the changes from this discussion fixes the one remaining failing unit test we have in `rclcpp_action`.